### PR TITLE
README.md: Update docker-toolbox download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install docker natively on Linux:
 
     $ sudo apt-get install docker.io
 
-... or install [docker-toolbox for Windows and OSX](https://www.docker.com/docker-toolbox) or boot2docker on [Windows](https://github.com/boot2docker/windows-installer/releases) or [OS X](https://github.com/boot2docker/osx-installer/releases) .
+... or install [docker-toolbox for Windows and OSX](https://github.com/docker/toolbox/releases) or boot2docker on [Windows](https://github.com/boot2docker/windows-installer/releases) or [OS X](https://github.com/boot2docker/osx-installer/releases) .
 
 Install rake-compiler-dock as a gem. The docker image is downloaded later on demand:
 


### PR DESCRIPTION
Docker Toolbox for Windows is no longer available from the Docker Website.
Docker Desktop is available instead but it doesn't work with VirtualBox which rake-compiler-dock uses.