### PR TITLE
Do not call STDIN.cooked! unless it is a tty

### DIFF
--- a/lib/rake_compiler_dock/starter.rb
+++ b/lib/rake_compiler_dock/starter.rb
@@ -13,7 +13,7 @@ module RakeCompilerDock
         begin
           exec('bash', '-c', cmd, options, &block)
         ensure
-          STDIN.cooked!
+          STDIN.cooked! if STDIN.tty?
         end
       end
 


### PR DESCRIPTION
Ref: https://github.com/protocolbuffers/protobuf/pull/7027

We're trying to build `google-protocol` buffers for Ruby 2.7, but the build is failing with:

```
Errno::ENOTTY: Inappropriate ioctl for device
/usr/local/rvm/gems/ruby-2.4.1/gems/rake-compiler-dock-1.0.0/lib/rake_compiler_dock/starter.rb:16:in `cooked!'
/usr/local/rvm/gems/ruby-2.4.1/gems/rake-compiler-dock-1.0.0/lib/rake_compiler_dock/starter.rb:16:in `ensure in sh'
/usr/local/rvm/gems/ruby-2.4.1/gems/rake-compiler-dock-1.0.0/lib/rake_compiler_dock/starter.rb:16:in `sh'
/usr/local/rvm/gems/ruby-2.4.1/gems/rake-compiler-dock-1.0.0/lib/rake_compiler_dock.rb:46:in `sh'
/tmpfs/src/github/protobuf/ruby/Rakefile:73:in `block in <top (required)>'
/usr/local/rvm/gems/ruby-2.4.1/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/usr/local/rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
```

@larskanis 