### PR TITLE
add support for ruby 3.0.0 preview1

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -25,9 +25,10 @@ COPY build/patches /home/rvm/patches/
 ENV BASH_ENV /etc/rubybashrc
 
 # install rubies and fix permissions on
+ENV RVM_RUBIES 2.5.7 2.7.0
 RUN bash -c " \
     export CFLAGS='-s -O3 -fno-fast-math -fPIC' && \
-    for v in 2.5.7 ; do \
+    for v in ${RVM_RUBIES} ; do \
         rvm install \$v --patch \$(echo ~/patches/ruby-\$v/* | tr ' ' ','); \
     done && \
     rvm cleanup all && \
@@ -66,15 +67,16 @@ RUN bash -c " \
         ruby /root/mk_i686.rb "
 <% end %>
 
-USER rvm
-
-COPY build/patches2 /home/rvm/patches/
 # Patch rake-compiler to build and install static libraries for Linux rubies
-RUN cd /usr/local/rvm/gems/ruby-2.5.7/gems/rake-compiler-1.1.0 && \
-    ( git apply /home/rvm/patches/rake-compiler-1.1.0/*.patch || true )
-RUN cd /usr/local/rvm/gems/ruby-2.5.7/gems/hoe-3.20.0 && \
-    ( git apply /home/rvm/patches/hoe-3.20.0/*.patch || true )
-
+USER rvm
+COPY build/patches2 /home/rvm/patches/
+RUN bash -c " \
+    for v in ${RVM_RUBIES} ; do \
+      cd /usr/local/rvm/gems/ruby-\$v/gems/rake-compiler-1.1.0 && \
+      ( git apply /home/rvm/patches/rake-compiler-1.1.0/*.patch || true ) && \
+      cd /usr/local/rvm/gems/ruby-\$v/gems/hoe-3.20.0 && \
+      ( git apply /home/rvm/patches/hoe-3.20.0/*.patch || true ) \
+    done "
 
 # Patch ruby-2.7.0 for cross build
 USER root
@@ -97,6 +99,13 @@ RUN bash -c " \
     export CFLAGS='-s -O1 -fno-omit-frame-pointer -fno-fast-math' && \
     export MAKE='make V=0' && \
     rake-compiler cross-ruby VERSION=$XRUBIES HOST=<%= target %> && \
+    rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources && \
+    find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
+
+RUN bash -c " \
+    export CFLAGS='-s -O1 -fno-omit-frame-pointer -fno-fast-math' && \
+    export MAKE='make V=0' && \
+    rvm 2.7.0 do rake-compiler cross-ruby VERSION=3.0.0-preview1 HOST=<%= target %> && \
     rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources && \
     find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
 
@@ -162,6 +171,6 @@ COPY build/runas /usr/local/bin/
 # Install sudoers configuration
 COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
-ENV RUBY_CC_VERSION 2.7.0:2.6.0:2.5.0:2.4.0:2.3.0:2.2.2
+ENV RUBY_CC_VERSION 3.0.0:2.7.0:2.6.0:2.5.0:2.4.0:2.3.0:2.2.2
 
 CMD bash

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -38,7 +38,7 @@ RUN bash -c " \
 RUN echo "gem: --no-ri --no-rdoc" >> ~/.gemrc && \
     bash -c " \
         rvm all do gem update --system --no-document && \
-        rvm all do gem install --no-document bundler 'bundler:~>1.16' rake-compiler hoe mini_portile rubygems-tasks mini_portile2 && \
+        rvm all do gem install --no-document bundler 'bundler:~>1.16' 'rake-compiler:1.1.0' 'hoe:3.20.0' mini_portile rubygems-tasks mini_portile2 && \
         find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
 
 # Install rake-compiler's cross rubies in global dir instead of /root

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ require_relative "build/parallel_docker_build"
 
 RakeCompilerDock::GemHelper.install_tasks
 
+DOCKERHUB_USER = ENV['DOCKERHUB_USER'] || "larskanis"
+
 namespace :build do
   platforms = [
     ["x86-mingw32", "i686-w64-mingw32"],
@@ -19,7 +21,7 @@ namespace :build do
     desc "Build image for platform #{platform}"
     task platform => sdf
     task sdf do
-      sh "docker build -t larskanis/rake-compiler-dock-mri-#{platform}:#{RakeCompilerDock::IMAGE_VERSION} -f Dockerfile.mri.#{platform} ."
+      sh "docker build -t #{DOCKERHUB_USER}/rake-compiler-dock-mri-#{platform}:#{RakeCompilerDock::IMAGE_VERSION} -f Dockerfile.mri.#{platform} ."
     end
 
     df = ERB.new(File.read("Dockerfile.mri.erb")).result(binding)
@@ -30,7 +32,7 @@ namespace :build do
   desc "Build image for JRuby"
   task :jruby => "Dockerfile.jruby"
   task "Dockerfile.jruby" do
-    sh "docker build -t larskanis/rake-compiler-dock-jruby:#{RakeCompilerDock::IMAGE_VERSION} -f Dockerfile.jruby ."
+    sh "docker build -t #{DOCKERHUB_USER}/rake-compiler-dock-jruby:#{RakeCompilerDock::IMAGE_VERSION} -f Dockerfile.jruby ."
   end
 
   RakeCompilerDock::ParallelDockerBuild.new(platforms.map{|pl, _| "Dockerfile.mri.#{pl}" } + ["Dockerfile.jruby"], workdir: "tmp/docker")

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ namespace :build do
   ]
   platforms.each do |platform, target|
     sdf = "Dockerfile.mri.#{platform}"
+
     desc "Build image for platform #{platform}"
     task platform => sdf
     task sdf do
@@ -33,6 +34,9 @@ namespace :build do
   end
 
   RakeCompilerDock::ParallelDockerBuild.new(platforms.map{|pl, _| "Dockerfile.mri.#{pl}" } + ["Dockerfile.jruby"], workdir: "tmp/docker")
+
+  desc "Build images for all MRI platforms in parallel"
+  multitask :mri => platforms.map(&:first)
 
   desc "Build images for all platforms in parallel"
   multitask :all => platforms.map(&:first) + ["jruby"]


### PR DESCRIPTION
I'd like to ship a Nokogiri release candidate with Ruby 3.0 support, and these are the changes that were necessary to do that:

- lock to the versions of rake-compiler and hoe for which we have patches
- `rvm install` ruby 2.7.0 in order to build ruby 3.0.0-preview1 (because 2.5.7 results in ruby2_keywords errors)

Additionally this patch set adds:

- a `build:mri` multitask
- optional setting of the Dockerhub username via `DOCKERHUB_USER` env var

I'm not at all saying this should be merged! But I wanted a public record of what I did in case that makes it easier to add Ruby 3.0 "final" support.