### PR TITLE
Add maven to image

### DIFF
--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get -y update && \
-    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-14-jdk-headless && \
+    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-14-jdk-headless maven && \
     rm -rf /var/lib/apt/lists/*
 
 # Add "rvm" as system group, to avoid conflicts with host GIDs typically starting with 1000


### PR DESCRIPTION
Many JRuby gems need maven to resolve dependencies on JARs, so make it available by default.