### PR TITLE
introduce failing test for some musl-incompatible code

### DIFF
--- a/test/rcd_test/ext/mri/rcd_test_ext.c
+++ b/test/rcd_test/ext/mri/rcd_test_ext.c
@@ -7,6 +7,20 @@
 VALUE rb_mRcdTest;
 
 static VALUE
+rcdt_isinf_eh(VALUE self, VALUE rb_float) {
+  Check_Type(rb_float, T_FLOAT);
+
+  return isinf(RFLOAT_VALUE(rb_float)) ? Qtrue : Qfalse;
+}
+
+static VALUE
+rcdt_isnan_eh(VALUE self, VALUE rb_float) {
+  Check_Type(rb_float, T_FLOAT);
+
+  return isnan(RFLOAT_VALUE(rb_float)) ? Qtrue : Qfalse;
+}
+
+static VALUE
 rcdt_do_something(VALUE self)
 {
   return rb_str_new_cstr("something has been done");
@@ -32,4 +46,6 @@ Init_rcd_test_ext(void)
   rb_mRcdTest = rb_define_module("RcdTest");
   rb_define_singleton_method(rb_mRcdTest, "do_something", rcdt_do_something, 0);
   rb_define_singleton_method(rb_mRcdTest, "darwin_builtin_available?", rcdt_darwin_builtin_available_eh, 0);
+  rb_define_singleton_method(rb_mRcdTest, "isinf?", rcdt_isinf_eh, 1);
+  rb_define_singleton_method(rb_mRcdTest, "isnan?", rcdt_isnan_eh, 1);
 }

--- a/test/rcd_test/test/test_basic.rb
+++ b/test/rcd_test/test/test_basic.rb
@@ -19,4 +19,13 @@ class TestBasic < Minitest::Test
       assert_equal("__builtin_available is not defined", e.message)
     end
   end
+
+  def test_floating_point_classification_macros
+    skip("jruby should not run libc-specific tests") if RUBY_ENGINE == "jruby"
+    refute(RcdTest.isinf?(42.0))
+    assert(RcdTest.isinf?(Float::INFINITY))
+    refute(RcdTest.isnan?(42.0))
+    assert(RcdTest.isnan?(Float::NAN))
+  end
+
 end


### PR DESCRIPTION
Originally reported as #42, which has more detail. The new test suite allows me to demonstrate the problem!

The summary of this issue is: centos/manylinux preprocesses `isnan` and `isinf` into C code that calls

```C
int __isnan(double) __attribute__ ((__const__));
```

but on musl these calls are preprocessed into code that make no function calls:

```C
#define isnan(x) ( \
	sizeof(x) == sizeof(float) ? (__FLOAT_BITS(x) & 0x7fffffff) > 0x7f800000 : \
	sizeof(x) == sizeof(double) ? (__DOUBLE_BITS(x) & -1ULL>>1) > 0x7ffULL<<52 : \
	__fpclassifyl(x) == FP_NAN)
```

I'm not sure what to do about this (in Nokogiri we patch libxml2 to avoid calling `isnan` or `isinf`) but I figured the first step is to reproduce the problem in a test.