### PR TITLE
small cleanup changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 /.bundle/
 /.yardoc
+/Dockerfile.mri.aarch64-linux
+/Dockerfile.mri.arm-linux
+/Dockerfile.mri.arm64-darwin
+/Dockerfile.mri.arm64-linux
+/Dockerfile.mri.x64-mingw32
 /Dockerfile.mri.x86-linux
 /Dockerfile.mri.x86-mingw32
+/Dockerfile.mri.x86_64-darwin
 /Dockerfile.mri.x86_64-linux
-/Dockerfile.mri.x64-mingw32
 /Gemfile.lock
 /_yardoc/
 /coverage/

--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ namespace :build do
     desc "Build image for platform #{platform}"
     task platform => sdf
     task sdf do
-      sh *docker_build_cmd, "-t", "#{DOCKERHUB_USER}/rake-compiler-dock-mri-#{platform}:#{RakeCompilerDock::IMAGE_VERSION}", "-f", "Dockerfile.mri.#{platform}", "."
+      sh(*docker_build_cmd, "-t", "#{DOCKERHUB_USER}/rake-compiler-dock-mri-#{platform}:#{RakeCompilerDock::IMAGE_VERSION}", "-f", "Dockerfile.mri.#{platform}", ".")
     end
 
     df = ERB.new(File.read("Dockerfile.mri.erb"), trim_mode: ">").result(binding)
@@ -39,7 +39,7 @@ namespace :build do
   desc "Build image for JRuby"
   task :jruby => "Dockerfile.jruby"
   task "Dockerfile.jruby" do
-    sh *docker_build_cmd, "-t", "#{DOCKERHUB_USER}/rake-compiler-dock-jruby:#{RakeCompilerDock::IMAGE_VERSION}", "-f", "Dockerfile.jruby", "."
+    sh(*docker_build_cmd, "-t", "#{DOCKERHUB_USER}/rake-compiler-dock-jruby:#{RakeCompilerDock::IMAGE_VERSION}", "-f", "Dockerfile.jruby", ".")
   end
 
   RakeCompilerDock::ParallelDockerBuild.new(platforms.map{|pl, _| "Dockerfile.mri.#{pl}" } + ["Dockerfile.jruby"], workdir: "tmp/docker", docker_build_cmd: docker_build_cmd)

--- a/build/parallel_docker_build.rb
+++ b/build/parallel_docker_build.rb
@@ -29,7 +29,7 @@ module RakeCompilerDock
     #    "File1"=>["      FROM a\n",
     #    ...
     def parse_dockerfiles(dockerfiles, inputdir)
-      files = dockerfiles.map do |fn|
+      dockerfiles.map do |fn|
         [fn, File.read(File.join(inputdir, fn))]
       end.map do |fn, f|
         # Split file contant in lines unless line ends with backslash
@@ -100,7 +100,7 @@ module RakeCompilerDock
     #
     # The layers will be reused in subsequent builds, even if they run in parallel.
     def docker_build(filename, workdir)
-      sh *docker_build_cmd, "-f", File.join(workdir, filename), "."
+      sh(*docker_build_cmd, "-f", File.join(workdir, filename), ".")
     end
   end
 end

--- a/test/test_parallel_docker_build.rb
+++ b/test/test_parallel_docker_build.rb
@@ -1,36 +1,47 @@
 require 'test/unit'
 require_relative "../build/parallel_docker_build"
+require "tmpdir"
 
 class TestParallelDockerBuild < Test::Unit::TestCase
   def setup
-    File.write "File0", <<-EOT
+    @tmpdir ||= Dir.mktmpdir
+
+    Dir.chdir(@tmpdir) do
+      File.write "File0", <<-EOT
       FROM a
       RUN a
       RUN d
     EOT
-    File.write "File1", <<-EOT
+      File.write "File1", <<-EOT
       FROM a
       RUN a
       RUN d
       RUN f \\
           g
     EOT
-    File.write "File2", <<-EOT
+      File.write "File2", <<-EOT
       FROM a
       RUN b
       RUN c
       RUN d
     EOT
-    File.write "File3", <<-EOT
+      File.write "File3", <<-EOT
       FROM a
       RUN b
       RUN c
       RUN d
     EOT
+    end
+  end
+
+  def teardown
+    FileUtils.rm_rf @tmpdir
   end
 
   def test_tasks
-    RakeCompilerDock::ParallelDockerBuild.new(%w[ File0 File1 File2 File3 ], task_prefix: "y")
+    Dir.chdir(@tmpdir) do
+      RakeCompilerDock::ParallelDockerBuild.new(%w[ File0 File1 File2 File3 ], task_prefix: "y")
+    end
 
     assert_operator Rake::Task["File0"].prerequisites, :include?, "yFile0File1"
     assert_operator Rake::Task["File1"].prerequisites, :include?, "yFile1"
@@ -43,7 +54,9 @@ class TestParallelDockerBuild < Test::Unit::TestCase
   end
 
   def test_common_files
-    RakeCompilerDock::ParallelDockerBuild.new(%w[ File0 File1 File2 File3 ], task_prefix: "y")
+    Dir.chdir(@tmpdir) do
+      RakeCompilerDock::ParallelDockerBuild.new(%w[ File0 File1 File2 File3 ], task_prefix: "y")
+    end
 
     assert_equal "FROM a\nRUN a\nRUN d\nRUN f \\\ng\n", read_df("yFile1")
     assert_equal "FROM a\nRUN a\nRUN d\n", read_df("yFile0File1")


### PR DESCRIPTION
This PR makes a few small nonfunctional changes:

- avoid Ruby warnings by adding parens to a few `Rake.sh` calls and removing an unused variable
- use a tmp directory for testing the parallel docker build, to avoid creating test files in the working directory
- ignore Dockerfiles for the recently-added architectures
