### PR TITLE
separate runas concerns

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -260,6 +260,8 @@ RUN gcc $HOME/sigfw.c -o /usr/bin/sigfw
 
 # Install user mapper
 COPY build/runas /usr/bin/
+COPY build/rcd-env.sh /etc/profile.d/
+RUN echo "source /etc/profile.d/rcd-env.sh" >> /etc/rubybashrc
 
 # Install sudoers configuration
 COPY build/sudoers /etc/sudoers.d/rake-compiler-dock

--- a/build/rcd-env.sh
+++ b/build/rcd-env.sh
@@ -1,0 +1,6 @@
+# set up a working RCD build environment
+export RAKE_EXTENSION_TASK_NO_NATIVE=true
+if ! test -e "$HOME"/.rake-compiler ; then
+  ln -s /usr/local/rake-compiler "$HOME"/.rake-compiler
+fi
+mkdir -p "$HOME"/.gem

--- a/build/runas
+++ b/build/runas
@@ -4,12 +4,4 @@ groupadd -o -g "$GID" "$GROUP"
 mkdir -p /tmp/home
 useradd -o -g "$GID" -u "$UID" -G rvm,sudo -p "" -b /tmp/home -m "$USER"
 
-HOME=$(bash <<< "echo ~$USER")
-ln -s /usr/local/rake-compiler "$HOME"/.rake-compiler
-mkdir -p "$HOME"/.gem
-chown "$USER" "$HOME"/.gem
-
-/usr/bin/sudo -u "$USER" -H \
-    BASH_ENV=/etc/rubybashrc \
-    RAKE_EXTENSION_TASK_NO_NATIVE=true \
-    -- "$@"
+/usr/bin/sudo -u "$USER" -H BASH_ENV=/etc/rubybashrc -- "$@"

--- a/test/test_environment_variables.rb
+++ b/test/test_environment_variables.rb
@@ -23,26 +23,10 @@ class TestEnvironmentVariables
       end
     end
 
-    def test_IMAGE
-      assert_equal IMAGE_NAME, rcd_env['RCD_IMAGE']
-    end
-
     def test_RUBY_CC_VERSION
       df = File.read(File.expand_path("../../Dockerfile.mri.erb", __FILE__))
       df =~ /^ENV RUBY_CC_VERSION\s+(.*)\s+$/
       assert_equal $1, rcd_env['RUBY_CC_VERSION']
-    end
-
-    def test_HOST_RUBY_PLATFORM
-      assert_equal RUBY_PLATFORM, rcd_env['RCD_HOST_RUBY_PLATFORM']
-    end
-
-    def test_HOST_RUBY_VERSION
-      assert_equal RUBY_VERSION, rcd_env['RCD_HOST_RUBY_VERSION']
-    end
-
-    def test_PWD
-      assert_equal Dir.pwd, rcd_env['PWD']
     end
 
     def test_RAKE_EXTENSION_TASK_NO_NATIVE
@@ -66,6 +50,30 @@ class TestEnvironmentVariables
     def invocation(command)
       idir = File.join(File.dirname(__FILE__), '../lib')
       "#{RbConfig::CONFIG['RUBY_INSTALL_NAME']} -I#{idir.inspect} bin/rake-compiler-dock bash -c '#{command}'"
+    end
+
+    def test_HOST_RUBY_PLATFORM
+      assert_equal RUBY_PLATFORM, rcd_env['RCD_HOST_RUBY_PLATFORM']
+    end
+
+    def test_HOST_RUBY_VERSION
+      assert_equal RUBY_VERSION, rcd_env['RCD_HOST_RUBY_VERSION']
+    end
+
+    def test_IMAGE
+      assert_equal IMAGE_NAME, rcd_env['RCD_IMAGE']
+    end
+
+    def test_PWD
+      assert_equal Dir.pwd, rcd_env['PWD']
+    end
+  end
+
+  class AsIfContinuousIntegration < Test::Unit::TestCase
+    include Common
+
+    def invocation(command)
+      "docker run -it #{IMAGE_NAME} bash -c '#{command}'"
     end
   end
 end

--- a/test/test_environment_variables.rb
+++ b/test/test_environment_variables.rb
@@ -6,62 +6,66 @@ begin
 rescue LoadError
 end
 
-class TestEnvironmentVariables < Test::Unit::TestCase
-  @@rcd_env = nil
+class TestEnvironmentVariables
+  module Common
+    IMAGE_NAME = "larskanis/rake-compiler-dock-mri-x86-mingw32:#{RakeCompilerDock::IMAGE_VERSION}"
 
-  def setup
-    @@rcd_env ||= begin
-      args = "bash -c 'set'"
-      idir = File.join(File.dirname(__FILE__), '../lib')
-      cmd = "#{RbConfig::CONFIG['RUBY_INSTALL_NAME']} -I#{idir.inspect} bin/rake-compiler-dock #{args}"
-      output = `#{cmd}`
+    def rcd_env
+      self.class.instance_variable_get("@rcd_env") || begin
+        command = "env"
+        output = %x(#{invocation(command)})
 
-      output.split("\n").inject({}) do |hash, line|
-        if line =~ /\A(\w+)=(.*)\z/
-          hash[$1] = $2.chomp
+        env = output.split("\n").each_with_object({}) do |line, hash|
+          hash[Regexp.last_match(1)] = Regexp.last_match(2).chomp if line =~ /\A(\w+)=(.*)\z/
         end
-        hash
+
+        self.class.instance_variable_set("@rcd_env", env)
       end
+    end
+
+    def test_IMAGE
+      assert_equal IMAGE_NAME, rcd_env['RCD_IMAGE']
+    end
+
+    def test_RUBY_CC_VERSION
+      df = File.read(File.expand_path("../../Dockerfile.mri.erb", __FILE__))
+      df =~ /^ENV RUBY_CC_VERSION\s+(.*)\s+$/
+      assert_equal $1, rcd_env['RUBY_CC_VERSION']
+    end
+
+    def test_HOST_RUBY_PLATFORM
+      assert_equal RUBY_PLATFORM, rcd_env['RCD_HOST_RUBY_PLATFORM']
+    end
+
+    def test_HOST_RUBY_VERSION
+      assert_equal RUBY_VERSION, rcd_env['RCD_HOST_RUBY_VERSION']
+    end
+
+    def test_PWD
+      assert_equal Dir.pwd, rcd_env['PWD']
+    end
+
+    def test_RAKE_EXTENSION_TASK_NO_NATIVE
+      assert_equal "true", rcd_env['RAKE_EXTENSION_TASK_NO_NATIVE']
+    end
+
+    def test_symlink_rake_compiler
+      cmd = invocation("if test -h $HOME/.rake-compiler ; then echo yes ; else echo no ; fi")
+      assert_equal("yes", %x(#{cmd}).strip)
+    end
+
+    def test_gem_directory
+      cmd = invocation("if test -d $HOME/.gem ; then echo yes ; else echo no ; fi")
+      assert_equal("yes", %x(#{cmd}).strip)
     end
   end
 
-  def rcd_env
-    @@rcd_env
-  end
+  class UsingWrapper < Test::Unit::TestCase
+    include Common
 
-  def test_IMAGE
-    assert_equal "larskanis/rake-compiler-dock-mri-x86-mingw32:#{RakeCompilerDock::IMAGE_VERSION}", rcd_env['RCD_IMAGE']
-  end
-
-  def test_RUBY_CC_VERSION
-    df = File.read(File.expand_path("../../Dockerfile.mri.erb", __FILE__))
-    df =~ /^ENV RUBY_CC_VERSION\s+(.*)\s+$/
-    assert_equal $1, rcd_env['RUBY_CC_VERSION']
-  end
-
-  def test_HOST_RUBY_PLATFORM
-    assert_equal RUBY_PLATFORM, rcd_env['RCD_HOST_RUBY_PLATFORM']
-  end
-
-  def test_HOST_RUBY_VERSION
-    assert_equal RUBY_VERSION, rcd_env['RCD_HOST_RUBY_VERSION']
-  end
-
-  def test_PWD
-    assert_equal Dir.pwd, rcd_env['PWD']
-  end
-
-  def test_RAKE_EXTENSION_TASK_NO_NATIVE
-    assert_equal "true", rcd_env['RAKE_EXTENSION_TASK_NO_NATIVE']
-  end
-
-  def test_symlink_rake_compiler
-    cmd = invocation("if test -h $HOME/.rake-compiler ; then echo yes ; else echo no ; fi")
-    assert_equal("yes", %x(#{cmd}).strip)
-  end
-
-  def test_gem_directory
-    cmd = invocation("if test -d $HOME/.gem ; then echo yes ; else echo no ; fi")
-    assert_equal("yes", %x(#{cmd}).strip)
+    def invocation(command)
+      idir = File.join(File.dirname(__FILE__), '../lib')
+      "#{RbConfig::CONFIG['RUBY_INSTALL_NAME']} -I#{idir.inspect} bin/rake-compiler-dock bash -c '#{command}'"
+    end
   end
 end

--- a/test/test_environment_variables.rb
+++ b/test/test_environment_variables.rb
@@ -51,4 +51,17 @@ class TestEnvironmentVariables < Test::Unit::TestCase
     assert_equal Dir.pwd, rcd_env['PWD']
   end
 
+  def test_RAKE_EXTENSION_TASK_NO_NATIVE
+    assert_equal "true", rcd_env['RAKE_EXTENSION_TASK_NO_NATIVE']
+  end
+
+  def test_symlink_rake_compiler
+    cmd = invocation("if test -h $HOME/.rake-compiler ; then echo yes ; else echo no ; fi")
+    assert_equal("yes", %x(#{cmd}).strip)
+  end
+
+  def test_gem_directory
+    cmd = invocation("if test -d $HOME/.gem ; then echo yes ; else echo no ; fi")
+    assert_equal("yes", %x(#{cmd}).strip)
+  end
 end


### PR DESCRIPTION
This addresses the concerns raised in #41

I'd like to make the rake-compiler-dock OCI images easier to use in CI systems by extracting the "build environment" setup out of `build/runas` and making it part of the non-interactive shell initialization.

This PR does a few things:

- generalizes the `test_environment_variables.rb` tests to run with the rake-compiler-dock wrapper and without it (as a bare docker command)
- introduces `build/rcd-env.sh` which contains the parts of `runas` unrelated to user/group/filesystem config
- ensures rcd-env.sh is loaded by all shells
- adds a section to the README with an example of how to use the images in a CI pipeline

The net result is that CI systems won't need to set environment variables in order to use the RCD images for gem building.
