### PR TITLE
test: reproduce issues with missing compiler-rt symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: Build docker images
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
 on: [push, pull_request]
 
 jobs:

--- a/test/rcd_test/ext/mri/rcd_test_ext.c
+++ b/test/rcd_test/ext/mri/rcd_test_ext.c
@@ -1,5 +1,9 @@
 #include "rcd_test_ext.h"
 
+#ifndef __has_builtin
+  #define __has_builtin(x) 0
+#endif
+
 VALUE rb_mRcdTest;
 
 static VALUE
@@ -8,9 +12,24 @@ rcdt_do_something(VALUE self)
   return rb_str_new_cstr("something has been done");
 }
 
+static VALUE
+rcdt_darwin_builtin_available_eh(VALUE self)
+{
+#if __has_builtin(__builtin_available)
+  // This version must be higher than MACOSX_DEPLOYMENT_TARGET to prevent clang from optimizing it away
+  if (__builtin_available(macOS 10.14, *)) {
+    return Qtrue;
+  }
+  return Qfalse;
+#else
+  rb_raise(rb_eRuntimeError, "__builtin_available is not defined");
+#endif
+}
+
 void
 Init_rcd_test_ext(void)
 {
   rb_mRcdTest = rb_define_module("RcdTest");
   rb_define_singleton_method(rb_mRcdTest, "do_something", rcdt_do_something, 0);
+  rb_define_singleton_method(rb_mRcdTest, "darwin_builtin_available?", rcdt_darwin_builtin_available_eh, 0);
 }

--- a/test/rcd_test/test/test_basic.rb
+++ b/test/rcd_test/test/test_basic.rb
@@ -9,4 +9,14 @@ class TestBasic < Minitest::Test
     assert_equal "something has been done", RcdTest.do_something
   end
 
+  def test_check_darwin_compiler_rt_symbol_resolution
+    skip("jruby should not run libc-specific tests") if RUBY_ENGINE == "jruby"
+
+    if RUBY_PLATFORM.include?("darwin")
+      assert(RcdTest.darwin_builtin_available?)
+    else
+      e = assert_raises(RuntimeError) { RcdTest.darwin_builtin_available? }
+      assert_equal("__builtin_available is not defined", e.message)
+    end
+  end
 end


### PR DESCRIPTION
The clang macro `__builtin_available` uses `___isOSVersionAtLeast`, which is defined in the `compiler-rt` runtime library. The `compiler-rt` library is not currently provided in the `rake-compiler-dock` environment, which means this symbol may end up being unresolved.

https://github.com/grpc/grpc/issues/28271 reports that the symbol `___isOSVersionAtLeast` is undefined at runtime. This PR attempts to reproduce that error.

Presuming that his test is valid and reproduces the issue, I have a second PR ready to go which adds `compiler-rt` to the darwin build environments that should make this test pass.
