### PR TITLE
fix(darwin): provide compiler-rt libraries for darwin builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: Build docker images
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
 on: [push, pull_request]
 
 jobs:

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -107,6 +107,8 @@ RUN git clone -q --depth=1 https://github.com/tpoechtrager/osxcross.git /opt/osx
     tar -cJf MacOSX11.1.sdk.tar.xz MacOSX11.1.sdk && \
     cd /opt/osxcross && \
     UNATTENDED=1 SDK_VERSION=11.1 OSX_VERSION_MIN=10.13 USE_CLANG_AS=1 ./build.sh && \
+    ln -s /usr/bin/llvm-config-10 /usr/bin/llvm-config && \
+    ENABLE_COMPILER_RT_INSTALL=1 SDK_VERSION=11.1 ./build_compiler_rt.sh && \
     rm -rf *~ build tarballs/*
 
 RUN echo "export PATH=/opt/osxcross/target/bin:\$PATH" >> /etc/rubybashrc && \

--- a/test/rcd_test/ext/mri/rcd_test_ext.c
+++ b/test/rcd_test/ext/mri/rcd_test_ext.c
@@ -1,5 +1,9 @@
 #include "rcd_test_ext.h"
 
+#ifndef __has_builtin
+  #define __has_builtin(x) 0
+#endif
+
 VALUE rb_mRcdTest;
 
 static VALUE
@@ -8,9 +12,24 @@ rcdt_do_something(VALUE self)
   return rb_str_new_cstr("something has been done");
 }
 
+static VALUE
+rcdt_darwin_builtin_available_eh(VALUE self)
+{
+#if __has_builtin(__builtin_available)
+  // This version must be higher than MACOSX_DEPLOYMENT_TARGET to prevent clang from optimizing it away
+  if (__builtin_available(macOS 10.14, *)) {
+    return Qtrue;
+  }
+  return Qfalse;
+#else
+  rb_raise(rb_eRuntimeError, "__builtin_available is not defined");
+#endif
+}
+
 void
 Init_rcd_test_ext(void)
 {
   rb_mRcdTest = rb_define_module("RcdTest");
   rb_define_singleton_method(rb_mRcdTest, "do_something", rcdt_do_something, 0);
+  rb_define_singleton_method(rb_mRcdTest, "darwin_builtin_available?", rcdt_darwin_builtin_available_eh, 0);
 }

--- a/test/rcd_test/test/test_basic.rb
+++ b/test/rcd_test/test/test_basic.rb
@@ -9,4 +9,14 @@ class TestBasic < Minitest::Test
     assert_equal "something has been done", RcdTest.do_something
   end
 
+  def test_check_darwin_compiler_rt_symbol_resolution
+    skip("jruby should not run libc-specific tests") if RUBY_ENGINE == "jruby"
+
+    if RUBY_PLATFORM.include?("darwin")
+      assert(RcdTest.darwin_builtin_available?)
+    else
+      e = assert_raises(RuntimeError) { RcdTest.darwin_builtin_available? }
+      assert_equal("__builtin_available is not defined", e.message)
+    end
+  end
 end


### PR DESCRIPTION
The clang macro `__builtin_available` uses `___isOSVersionAtLeast`, which is defined in the `compiler-rt` runtime library. The `compiler-rt` library is not currently provided in the `rake-compiler-dock` environment, which means this symbol may end up being unresolved.

grpc/grpc#28271 reports that the symbol `___isOSVersionAtLeast` is undefined at runtime. This issue is reproduced with the test at #59:

```
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Fetching rake 13.0.6
Installing rake 13.0.6
Using bundler 2.2.32
Fetching minitest 5.14.4
Fetching rake-compiler 1.1.1
Fetching rake-compiler-dock 1.1.0
Installing rake-compiler 1.1.1
Installing rake-compiler-dock 1.1.0
Installing minitest 5.14.4
Using rcd_test 1.0.0 from source at `.`
Bundle complete! 5 Gemfile dependencies, 6 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Run options: --seed 46435
dyld: lazy symbol binding failed: Symbol not found: ___isOSVersionAtLeast

  Referenced from: /Users/runner/hostedtoolcache/Ruby/3.0.3/x64/lib/ruby/gems/3.0.0/gems/rcd_test-1.0.0-x86_64-darwin/lib/rcd_test/3.0/rcd_test_ext.bundle
# Running:
  Expected in: flat namespace


.
dyld: Symbol not found: ___isOSVersionAtLeast
  Referenced from: /Users/runner/hostedtoolcache/Ruby/3.0.3/x64/lib/ruby/gems/3.0.0/gems/rcd_test-1.0.0-x86_64-darwin/lib/rcd_test/3.0/rcd_test_ext.bundle
  Expected in: flat namespace

rake aborted!
SignalException: SIGABRT

Tasks: TOP => test
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```

This PR includes that test, along with a proposed fix which is to add `compiler-rt` to the darwin build environments.

