### PR TITLE
Use openjdk 11 to make maven work on ubuntu 20.04

### DIFF
--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -1,8 +1,8 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && \
-    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-17-jdk-headless maven && \
+    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-11-jdk-headless maven && \
     rm -rf /var/lib/apt/lists/*
 
 # Add "rvm" as system group, to avoid conflicts with host GIDs typically starting with 1000

--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && \
-    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-17-jdk-headless maven && \
+    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-11-jdk-headless maven && \
     rm -rf /var/lib/apt/lists/*
 
 # Add "rvm" as system group, to avoid conflicts with host GIDs typically starting with 1000

--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -1,8 +1,8 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && \
-    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-11-jdk-headless maven && \
+    apt-get install -y curl git-core xz-utils wget unzip sudo gpg dirmngr openjdk-17-jdk-headless maven && \
     rm -rf /var/lib/apt/lists/*
 
 # Add "rvm" as system group, to avoid conflicts with host GIDs typically starting with 1000

--- a/test/rcd_test/Rakefile
+++ b/test/rcd_test/Rakefile
@@ -56,6 +56,7 @@ namespace "gem" do
     require 'rake_compiler_dock'
     sh "bundle package --all"
     RakeCompilerDock.sh <<-EOT, rubyvm: "jruby", platform: "jruby", mountdir: Dir.pwd + "/../.."
+      mvn &&
       bundle --local &&
       bundle exec rake java gem
     EOT

--- a/test/rcd_test/Rakefile
+++ b/test/rcd_test/Rakefile
@@ -56,7 +56,7 @@ namespace "gem" do
     require 'rake_compiler_dock'
     sh "bundle package --all"
     RakeCompilerDock.sh <<-EOT, rubyvm: "jruby", platform: "jruby", mountdir: Dir.pwd + "/../.."
-      mvn &&
+      mvn archetype:generate -DartifactId=test -DarchetypeVersion=1.4 -DinteractiveMode=false -DgroupId=test -Dpackage=test &&
       bundle --local &&
       bundle exec rake java gem
     EOT


### PR DESCRIPTION
The current version of maven, which comes with ubuntu 20.04, does not work with jdk 16/17 as per https://bugs.launchpad.net/ubuntu/+source/maven/+bug/1930541

In order to have maven working in the docker container, the only solution I could come up with is to go back to jdk 11, while also maintaining ubuntu:20.04 as the base for the image. 

Another solution would be to use 21.10. but that's not LTS. Hopefully the new LTS version of ubuntu won't have this problem, but it's not there yet.