### PR TITLE
Use manylinux Docker image for aarch64-linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Enable Multiarch
         run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
         if: matrix.platform == 'aarch64-linux'
 
       - name: Create builder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,35 @@ jobs:
           ruby-version: "3.0"
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+        if: matrix.platform == 'aarch64-linux'
+
+      - name: Enable Multiarch
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        if: matrix.platform == 'aarch64-linux'
+
+      - name: Create builder
+        run: |
+          docker buildx create --name mbuilder
+          docker buildx use mbuilder
+          docker buildx inspect
+          docker buildx ls
+        if: matrix.platform == 'aarch64-linux'
+
+      - name: Export Docker Buildx arguments
+        run: |
+          echo "DOCKER_BUILDX_ARGS=--platform=linux/arm64" >> $GITHUB_ENV
+        if: matrix.platform == 'aarch64-linux'
+
       - name: Build docker image
         run: |
           docker buildx create --driver docker-container --use
-          bundle exec rake build:${PLATFORM} RCD_DOCKER_BUILD="docker buildx build --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load"
+          bundle exec rake build:${PLATFORM} RCD_DOCKER_BUILD="docker buildx build ${DOCKER_BUILDX_ARGS} --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load"
 
       - name: Move build cache and remove outdated layers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,35 +43,15 @@ jobs:
           ruby-version: "3.0"
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          install: true
-        if: matrix.platform == 'aarch64-linux'
-
       - name: Enable Multiarch
         run: |
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
         if: matrix.platform == 'aarch64-linux'
 
-      - name: Create builder
-        run: |
-          docker buildx create --name mbuilder
-          docker buildx use mbuilder
-          docker buildx inspect
-          docker buildx ls
-        if: matrix.platform == 'aarch64-linux'
-
-      - name: Export Docker Buildx arguments
-        run: |
-          echo "DOCKER_BUILDX_ARGS=--platform=linux/arm64" >> $GITHUB_ENV
-        if: matrix.platform == 'aarch64-linux'
-
       - name: Build docker image
         run: |
           docker buildx create --driver docker-container --use
-          bundle exec rake build:${PLATFORM} RCD_DOCKER_BUILD="docker buildx build ${DOCKER_BUILDX_ARGS} --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load"
+          bundle exec rake build:${PLATFORM} RCD_DOCKER_BUILD="docker buildx build --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load"
 
       - name: Move build cache and remove outdated layers
         run: |

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -1,5 +1,6 @@
 <%
 image = case platform
+  when /aarch64-linux/ then "quay.io/pypa/manylinux2014_aarch64"
   when /x86_64-linux/ then "quay.io/pypa/manylinux2014_x86_64"
   when /x86-linux/ then "quay.io/pypa/manylinux2014_i686"
   else "ubuntu:20.04"

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -91,7 +91,6 @@ RUN dpkg -i /debs/*.deb
 RUN apt-get -y update && \
     apt-get install -y <%
 if platform=~/darwin/        %> clang python lzma-dev libxml2-dev libssl-dev libc++-10-dev <% end %><%
-if platform=~/aarch64-linux/ %> gcc-aarch64-linux-gnu g++-aarch64-linux-gnu <% end %><%
 if platform=~/arm-linux/     %> gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf <% end %><%
 if platform=~/x86-mingw32/   %> gcc-mingw-w64-i686 g++-mingw-w64-i686 <% end %><%
 if platform=~/x64-mingw32/   %> gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 <% end %> && \


### PR DESCRIPTION
Previously Ubuntu 20.04 was used to build `aarch64-linux`, which
caused native gems to require glibc v2.29 or higher. However, this
prevented native gems from being used on Amazon Linux 2, Debian 10,
and more.

To improve this, let's use the manylinux 2014 image as we do with the
x86 builds. Since this image is based off CentOS 7, which uses glibc
2.16, this significantly improves the compatiblity of ARM64 builds.

Relates to https://github.com/sparklemotion/nokogiri/issues/2470