### PR TITLE
fix windows ucrt library filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           gem install -l rake-compiler-dock-*.gem
           cd test/rcd_test/
           bundle install
+          bundle exec rake clean clobber
           bundle exec rake gem:${PLATFORM}
 
       - name: Upload binary gem
@@ -77,16 +78,34 @@ jobs:
           name: gem-${{ matrix.platform }}
           path: test/rcd_test/pkg/*-*-*.gem
 
-      - name: Upload source gem
+      - if: matrix.platform == 'jruby'
+        name: Upload source gem
         uses: actions/upload-artifact@v2
-        if: matrix.platform == 'jruby'
         with:
           name: gem-ruby
           path: test/rcd_test/pkg/*-?.?.?.gem
 
+      - if: contains(matrix.platform, 'x64-mingw')
+        name: Build static rcd_test.gem
+        env:
+          RCD_TEST_CONFIG: "--link-static"
+        run: |
+          gem build rake-compiler-dock.gemspec
+          gem install -l rake-compiler-dock-*.gem
+          cd test/rcd_test/
+          bundle install
+          bundle exec rake clean clobber
+          bundle exec rake gem:${PLATFORM}
+
+      - if: contains(matrix.platform, 'x64-mingw')
+        name: Upload static binary gem
+        uses: actions/upload-artifact@v2
+        with:
+          name: gem-${{ matrix.platform }}-static
+          path: test/rcd_test/pkg/*-*-*.gem
 
   job_test_native:
-    name: Test ${{matrix.ruby}} ${{matrix.platform}}
+    name: Test (${{matrix.ruby}}, ${{matrix.platform}})
     needs: docker_build
     strategy:
       fail-fast: false
@@ -133,6 +152,50 @@ jobs:
         with:
           name: gem-${{ matrix.platform }}
       - name: Install gem-${{matrix.platform}}
+        run: gem install --local *.gem --verbose
+      - name: Run tests
+        run: |
+          cd test/rcd_test/
+          bundle install
+          ruby -rrcd_test -S rake test
+
+  job_test_native_static:
+    name: Test static (${{matrix.ruby}}, ${{matrix.platform}})
+    needs: docker_build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows
+        ruby:
+          - "3.1"
+          - "3.0"
+          - "2.7"
+          - "2.6"
+          - "2.5"
+          - "2.4"
+        include:
+          - os: windows
+            platform: x64-mingw32
+          - os: windows
+            ruby: "3.1"
+            platform: x64-mingw-ucrt
+        exclude:
+          - os: windows
+            ruby: "3.1"
+
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: ruby --version
+      - name: Download gem-${{matrix.platform}}-static
+        uses: actions/download-artifact@v2
+        with:
+          name: gem-${{ matrix.platform }}-static
+      - name: Install gem-${{matrix.platform}}-static
         run: gem install --local *.gem --verbose
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,17 @@ name: Build docker images
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
   cancel-in-progress: true
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "*.*.*"
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - "*"
 
 jobs:
   # These jobs use Buildx layer caching
@@ -12,17 +22,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: x86-mingw32
-          - platform: x64-mingw-ucrt
-          - platform: x64-mingw32
-          - platform: x86-linux
-          - platform: x86_64-linux
-          - platform: x86_64-darwin
-          - platform: arm64-darwin
-          - platform: arm-linux
-          - platform: aarch64-linux
-          - platform: jruby
+        platform:
+          - x86-mingw32
+          - x64-mingw-ucrt
+          - x64-mingw32
+          - x86-linux
+          - x86_64-linux
+          - x86_64-darwin
+          - arm64-darwin
+          - arm-linux
+          - aarch64-linux
+          - jruby
 
     runs-on: ubuntu-latest
     env:
@@ -76,54 +86,54 @@ jobs:
 
 
   job_test_native:
-    name: Test
+    name: Test ${{matrix.ruby}} ${{matrix.platform}}
     needs: docker_build
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - windows
+          - macos
+          - ubuntu
+        ruby:
+          - "3.1"
+          - "3.0"
+          - "2.7"
+          - "2.6"
+          - "2.5"
+          - "2.4"
         include:
           - os: windows
-            ruby: "3.0"
-            platform: x64-mingw32
-          - os: windows
-            ruby: "2.4"
             platform: x64-mingw32
           - os: macos
-            ruby: "3.0"
-            platform: x86_64-darwin
-          - os: macos
-            ruby: "2.4"
             platform: x86_64-darwin
           - os: ubuntu
-            ruby: "3.0"
             platform: x86_64-linux
           - os: ubuntu
-            ruby: "2.4"
-            platform: x86_64-linux
+            platform: ruby
           - os: ubuntu
             ruby: jruby-head
             platform: jruby
-          - os: ubuntu
-            ruby: "3.0"
-            platform: ruby
+          - os: windows
+            ruby: "3.1"
+            platform: x64-mingw-ucrt
+        exclude:
+          - os: windows
+            ruby: "3.1"
 
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
       - run: ruby --version
-
-      - name: Download gem from build job
+      - name: Download gem-${{matrix.platform}}
         uses: actions/download-artifact@v2
         with:
           name: gem-${{ matrix.platform }}
-
-      - run: gem install --local *.gem --verbose
-
+      - name: Install gem-${{matrix.platform}}
+        run: gem install --local *.gem --verbose
       - name: Run tests
         run: |
           cd test/rcd_test/
@@ -131,7 +141,7 @@ jobs:
           ruby -rrcd_test -S rake test
 
   job_test_multiarch:
-    name: Test
+    name: Test ${{matrix.platform}} on ${{matrix.from_image}}
     needs: docker_build
     strategy:
       fail-fast: false
@@ -156,11 +166,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download gem from build job
+      - name: Download gem-${{matrix.platform}}
         uses: actions/download-artifact@v2
         with:
           name: gem-${{ matrix.platform }}
-
       - name: Build image and Run tests
         run: |
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -217,7 +217,7 @@ RUN find /usr/local/rake-compiler/ruby/*mingw*/ -name rbconfig.rb | while read f
 # Raise Windows-API to Vista (affects ruby < 2.6 only)
 RUN find /usr/local/rake-compiler/ruby -name rbconfig.rb | while read f ; do sed -i 's/0x0501/0x0600/' $f ; done
 # Don't link to static libruby
-RUN find /usr/local/rake-compiler/ruby -name *msvcrt-ruby*.dll.a | while read f ; do n=`echo $f | sed s/.dll//` ; mv $f $n ; done
+RUN find /usr/local/rake-compiler/ruby -name lib*-ruby*.dll.a | while read f ; do n=`echo $f | sed s/.dll//` ; mv $f $n ; done
 <% end %>
 
 USER root

--- a/test/rcd_test/Rakefile
+++ b/test/rcd_test/Rakefile
@@ -41,11 +41,12 @@ namespace "gem" do
 
       desc "Build the native gem for #{plat}"
       task plat => 'prepare' do
+        config = "-- #{ENV['RCD_TEST_CONFIG']}"
         # Set mountdir of the directory where .git resides, so that git ls-files in the gemspec works
         RakeCompilerDock.sh <<-EOT, platform: plat, mountdir: Dir.pwd + "/../.."
           (cp tmp/gem/gem-*.pem ~/.gem/ || true) &&
           bundle --local &&
-          rake native:#{plat} pkg/#{exttask.gem_spec.full_name}-#{plat}.gem
+          rake native:#{plat} pkg/#{exttask.gem_spec.full_name}-#{plat}.gem #{config}
         EOT
       end
     end

--- a/test/rcd_test/ext/mri/extconf.rb
+++ b/test/rcd_test/ext/mri/extconf.rb
@@ -19,5 +19,11 @@ else
   have_func('rb_thread_call_without_gvl', 'ruby/thread.h') ||
       raise("rb_thread_call_without_gvl() not found")
 
+  if arg_config("--link-static", false)
+    # https://github.com/rake-compiler/rake-compiler-dock/issues/69
+    puts "Linking with '-static' flag"
+    $LDFLAGS << ' -static'
+  end
+
   create_makefile("rcd_test/rcd_test_ext")
 end


### PR DESCRIPTION
Fix the DLL naming issue described at https://github.com/rake-compiler/rake-compiler-dock/issues/69 and https://github.com/grpc/grpc/pull/30081

This PR will be three commits, and I'm using CI to provide signal after the second and third:

- [x] expand CI coverage to include more versions of Ruby including 3.1 on windows (ucrt)
- [x] add tests to build static libraries (these will fail with ucrt)
- [x] fix the file names in the Dockerfile

I'll leave it in draft mode until I get to the final commit.
