### PR TITLE
get CI to green again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ concurrency:
   cancel-in-progress: true
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 3" # At 05:00 on Wednesday # https://crontab.guru/#0_5_*_*_3
   push:
     branches:
       - main

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -61,9 +61,10 @@ RUN bash -c " \
 
 # Install rake-compiler and typical gems in all Rubies
 # do not generate documentation for gems
+# TODO: stop pinning rubygems to 3.3.20 once https://github.com/rake-compiler/rake-compiler/pull/209 is merged
 RUN echo "gem: --no-ri --no-rdoc" >> ~/.gemrc && \
     bash -c " \
-        rvm all do gem update --system --no-document && \
+        rvm all do gem update --system=3.3.20 --no-document && \
         rvm all do gem install --no-document bundler 'bundler:~>1.16' 'rake-compiler:1.1.6' hoe mini_portile rubygems-tasks mini_portile2 && \
         find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
 

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -19,7 +19,7 @@ RUN rm -f /usr/local/bin/sudo && \
 <% else %>
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -y update && \
-    apt-get install -y curl git-core xz-utils build-essential zlib1g-dev libreadline-dev libssl-dev wget unzip sudo gnupg2 dirmngr cmake pkg-config && \
+    apt-get install -y curl git-core xz-utils build-essential zlib1g-dev libreadline-dev libssl-dev wget unzip sudo gnupg2 dirmngr cmake pkg-config autoconf && \
     rm -rf /var/lib/apt/lists/*
 <% end %>
 


### PR DESCRIPTION
This PR's commits:

1. fix(temp): work around rubygems platform matching

    Pin rubygems to 3.3.20 to avoid the problem discussed at https://github.com/rake-compiler/rake-compiler/pull/209. This should get the linux builds back to green.

    This should be reverted once that PR gets merged upstream.

2. Install `autoconf` because recent RVM started using `autogen.sh` during ruby installation

3. Run this pipeline every wednesday so we can see if something breaks.

Closes #80 