### PR TITLE
[draft] ruby 3.2 support

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -167,6 +167,7 @@ RUN bash -c " \
 axrubies = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1.0+ is platform x64-mingw-ucrt
+    ["3.2.0-rc1", "3.1.0", true],
     ["3.1.0", "3.1.0", true],
   ]
 elsif platform =~ /x64-mingw32/
@@ -180,7 +181,7 @@ else
     # Build xruby versions prior ruby2_keywords in parallel using ruby-2.5
     ["2.6.0:2.5.0:2.4.0", "2.5.9", false],
     # Build xruby versions with ruby2_keywords in parallel using ruby-3.x
-    ["3.1.0:3.0.0:2.7.0", "3.1.0", true],
+    ["3.2.0-rc1:3.1.0:3.0.0:2.7.0", "3.1.0", true],
   ]
 end
 
@@ -273,6 +274,6 @@ RUN echo "source /etc/profile.d/rcd-env.sh" >> /etc/rubybashrc
 # Install sudoers configuration
 COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
-ENV RUBY_CC_VERSION 3.1.0:3.0.0:2.7.0:2.6.0:2.5.0:2.4.0
+ENV RUBY_CC_VERSION 3.2.0:3.1.0:3.0.0:2.7.0:2.6.0:2.5.0:2.4.0
 
 CMD bash

--- a/build/patches2/rake-compiler-1.1.6/0005-make-miniruby.patch
+++ b/build/patches2/rake-compiler-1.1.6/0005-make-miniruby.patch
@@ -1,0 +1,19 @@
+fix(temp): rake-compiler explicitly builds miniruby first
+
+See https://bugs.ruby-lang.org/issues/19239 for the upstream bug
+report.
+
+TODO: This patch can be removed if that's fixed in a 3.2.0 final release.
+
+diff --git a/tasks/bin/cross-ruby.rake b/tasks/bin/cross-ruby.rake
+index 8317a2a..d9bfe4c 100644
+--- a/tasks/bin/cross-ruby.rake
++++ b/tasks/bin/cross-ruby.rake
+@@ -129,6 +129,7 @@
+ 
+     # make
+     file "#{build_dir}/ruby.exe" => ["#{build_dir}/Makefile"] do |t|
++      sh "#{MAKE} miniruby", chdir: File.dirname(t.prerequisites.first)
+       sh MAKE, chdir: File.dirname(t.prerequisites.first)
+     end
+ 


### PR DESCRIPTION
This is a naive attempt (based on #81) to add Ruby 3.2.0 support using the recent rc1.

I've built the x86_64-linux image on my dev machine, and used it to build Nokogiri libraries that support 3.2 and pass all the tests.

The changes I made to Nokogiri are:

```patch
diff --git a/.cross_rubies b/.cross_rubies
index b585a0e..5c42e9c 100644
--- a/.cross_rubies
+++ b/.cross_rubies
@@ -30,3 +30,11 @@
 3.1.0:x86-mingw32
 3.1.0:x86_64-darwin
 3.1.0:x86_64-linux
+3.2.0:aarch64-linux
+3.2.0:arm-linux
+3.2.0:arm64-darwin
+3.2.0:x64-mingw-ucrt
+3.2.0:x86-linux
+3.2.0:x86-mingw32
+3.2.0:x86_64-darwin
+3.2.0:x86_64-linux
diff --git a/rakelib/extensions.rake b/rakelib/extensions.rake
index aabdb3e..ef67f9a 100644
--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -168,7 +168,7 @@ def allowed_dlls
         "libc.so.6",
         "libdl.so.2", # on old dists only - now in libc
       ].tap do |dlls|
-        dlls << "libpthread.so.0" if ver < "2.6.0"
+        dlls << "libpthread.so.0" if ver < "2.6.0" or ver >= "3.2.0"
       end
     when AARCH_LINUX_PLATFORM_REGEX
       [
```

I'm not sure why `libpthread.so.0` shows up as a shared object dependency, when it hasn't been one since 2.5. @larskanis any ideas on that? It seems OK, the tests pass.