### PR TITLE
publish image snapshots to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
     env:
       PLATFORM: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: tmp/build-cache
           key: ${{ runner.os }}-${{ matrix.platform }}-buildx-${{ github.sha }}
@@ -75,14 +75,14 @@ jobs:
           bundle exec rake gem:${PLATFORM}
 
       - name: Upload binary gem
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gem-${{ matrix.platform }}
           path: test/rcd_test/pkg/*-*-*.gem
 
       - if: matrix.platform == 'jruby'
         name: Upload source gem
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gem-ruby
           path: test/rcd_test/pkg/*-?.?.?.gem
@@ -101,7 +101,7 @@ jobs:
 
       - if: contains(matrix.platform, 'x64-mingw')
         name: Upload static binary gem
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gem-${{ matrix.platform }}-static
           path: test/rcd_test/pkg/*-*-*.gem
@@ -144,13 +144,13 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: ruby --version
       - name: Download gem-${{matrix.platform}}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gem-${{ matrix.platform }}
       - name: Install gem-${{matrix.platform}}
@@ -188,13 +188,13 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: ruby --version
       - name: Download gem-${{matrix.platform}}-static
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gem-${{ matrix.platform }}-static
       - name: Install gem-${{matrix.platform}}-static
@@ -230,9 +230,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download gem-${{matrix.platform}}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: gem-${{ matrix.platform }}
       - name: Build image and Run tests

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,8 +4,62 @@ concurrency:
   cancel-in-progress: true
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 3" # At 03:00 on Wednesday # https://crontab.guru/#0_3_*_*_3
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - x86-mingw32
+          - x64-mingw-ucrt
+          - x64-mingw32
+          - x86-linux
+          - x86_64-linux
+          - x86_64-darwin
+          - arm64-darwin
+          - arm-linux
+          - aarch64-linux
+        include:
+          - platform: jruby
+            tag: jruby
+    runs-on: ubuntu-latest
     steps:
-      - run: echo "this is a stub pipeline so that I can ship a working version in #84"
+      - uses: actions/checkout@v3
+      - name: Use cache from primary pipeline
+        uses: actions/cache@v3
+        with:
+          path: tmp/build-cache
+          key: ${{runner.os}}-${{matrix.platform}}-buildx-${{github.sha}}
+          restore-keys: |
+            ${{runner.os}}-${{matrix.platform}}-buildx
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - id: rcd_image_version
+        run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "rcd_image_version=#{RakeCompilerDock::IMAGE_VERSION}"' >> $GITHUB_OUTPUT
+      - name: Build docker image
+        env:
+          DOCKERHUB_USER: rake-compiler
+          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load
+        run: |
+          docker buildx create --driver docker-container --use
+          bundle exec rake build:${{matrix.platform}}
+          # move build cache and remove outdated layers
+          rm -rf tmp/build-cache
+          mv tmp/build-cache-new tmp/build-cache
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - env:
+          OLD_TAG: rake-compiler/rake-compiler-dock-${{matrix.tag || format('mri-{0}', matrix.platform)}}:${{steps.rcd_image_version.outputs.rcd_image_version}}
+          NEW_TAG: ghcr.io/rake-compiler/rake-compiler-dock-snapshot:${{matrix.platform}}
+        run: |
+          docker images
+          docker tag ${OLD_TAG} ${NEW_TAG}
+          docker push ${NEW_TAG}

--- a/README.md
+++ b/README.md
@@ -218,6 +218,18 @@ end
 
 For an example of rake tasks that support this style of invocation, visit https://github.com/flavorjones/ruby-c-extensions-explained/tree/main/precompiled
 
+
+### Living on the edge: using weekly snapshots
+
+OCI images snapshotted from `master` are published weekly to Github Container Registry:
+
+> https://github.com/rake-compiler/rake-compiler-dock/pkgs/container/rake-compiler-dock-snapshot
+
+The images are named `ghcr.io/rake-compiler/rake-compiler-dock-snapshot` and are tagged with the platform name (e.g., `ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x86_64-linux`.
+
+These images are intended for integration testing. They may not work properly and should not be considered production ready.
+
+
 ## Environment Variables
 
 Rake-compiler-dock makes use of several environment variables.


### PR DESCRIPTION
See #71 for context.

This is a draft to try to publish snapshots of the docker images to ghcr.io for integration testing on other projects.