### PR TITLE
darwin: work around the Ruby 3.2 symbol resolution changes

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -190,6 +190,15 @@ RUN find /usr/local/rake-compiler/ruby -name rbconfig.rb | while read f ; do sed
 RUN find /usr/local/rake-compiler/ruby -name lib*-ruby*.dll.a | while read f ; do n=`echo $f | sed s/.dll//` ; mv $f $n ; done
 <% end %>
 
+# ruby-2.5 links to libcrypt, which isn't necessary for extensions
+RUN find /usr/local/rake-compiler/ruby -name rbconfig.rb | while read f ; do sed -i 's/-lcrypt//' $f ; done
+
+<% if platform=~/darwin/ %>
+# ruby-3.2 on darwin links with `-bundle_loader`, see https://github.com/rake-compiler/rake-compiler-dock/issues/87
+RUN find /usr/local/rake-compiler/ruby/*/*/lib/ruby/3.2.0 -name rbconfig.rb | \
+    while read f ; do sed -i 's/\["EXTDLDFLAGS"\] = "/&-Wl,-flat_namespace /' $f ; done
+<% end %>
+
 ##
 ##  Final adjustments
 ##
@@ -217,9 +226,6 @@ RUN echo "export PATH=\$DEVTOOLSET_ROOTPATH/usr/bin:\$PATH" >> /etc/rubybashrc
 
 # Add prefixed versions of compiler tools
 RUN for f in addr2line gcc gcov-tool ranlib ar dwp gcc-ranlib nm readelf as elfedit gcc-ar gprof objcopy size c++filt g++ gcov ld objdump strings cpp gcc-nm pkg-config strip ; do ln -sf $DEVTOOLSET_ROOTPATH/usr/bin/$f $DEVTOOLSET_ROOTPATH/usr/bin/<%= target %>-$f ; done
-
-# ruby-2.5 links to libcrypt, which isn't necessary for extensions
-RUN find /usr/local/rake-compiler/ruby -name rbconfig.rb | while read f ; do sed -i 's/-lcrypt//' $f ; done
 
 # Use builtin functions of newer gcc to avoid linker issues on Musl based Linux
 COPY build/math_h.patch /root/

--- a/test/rcd_test/ext/mri/extconf.rb
+++ b/test/rcd_test/ext/mri/extconf.rb
@@ -79,13 +79,15 @@ else
       ##
       ## This returns us to the symbol resolution we had in previous Rubies. It feels gross but may
       ## be a workaround for gem maintainers until we all figure out a better way to deal with this.
-      extdldflags = RbConfig::MAKEFILE_CONFIG["EXTDLDFLAGS"].split
-      if found = extdldflags.index("-bundle_loader")
-        removed_1 = extdldflags.delete_at(found) # flag
-        removed_2 = extdldflags.delete_at(found) # and its argument
-        puts "Removing '#{removed_1} #{removed_2}' from EXTDLDFLAGS"
-      end
-      RbConfig::MAKEFILE_CONFIG["EXTDLDFLAGS"] = extdldflags.join(" ")
+      #
+      # extdldflags = RbConfig::MAKEFILE_CONFIG["EXTDLDFLAGS"].split
+      # if found = extdldflags.index("-bundle_loader")
+      #   removed_1 = extdldflags.delete_at(found) # flag
+      #   removed_2 = extdldflags.delete_at(found) # and its argument
+      #   puts "Removing '#{removed_1} #{removed_2}' from EXTDLDFLAGS"
+      # end
+      # RbConfig::MAKEFILE_CONFIG["EXTDLDFLAGS"] = extdldflags.join(" ")
+      #
     end
   end
 


### PR DESCRIPTION
## Summary

This PR introduces the `-Wl,-flat_namespace` linker flag into the Darwin Ruby 3.2 build environments.

## Context

See lengthy conversations at these issues for context

- https://github.com/rake-compiler/rake-compiler-dock/issues/87
- https://github.com/sparklemotion/nokogiri/pull/2732

After building RCs of precompiled gems for both nokogiri and sqlite3, I found that I needed to add this flag in order for the extension to be able to resolve basic symbols like `rb_cObject` when running against a version of Ruby compiled with the `--enable-shared` config flag.

I cannot imagine any scenario where someone would be precompiling a Ruby 3.2 Darwin bundle and not want this flag on given the current state of the universe. 

## Details

- Commit 1 removes workaround from rcd_test to demonstrate the failure condition. See it fail at https://github.com/rake-compiler/rake-compiler-dock/actions/runs/3825200112/jobs/6508011916#step:7:22
- Commit 2 moves the workaround into RCD's rbconfig. See it pass at https://github.com/rake-compiler/rake-compiler-dock/actions/runs/3825232096/jobs/6508074546#step:7:30
