### PR TITLE
change location of docker images to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           docker buildx create --driver docker-container --use
           bundle exec rake build:${PLATFORM} RCD_DOCKER_BUILD="docker buildx build --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load"
+          docker images
 
       - name: Move build cache and remove outdated layers
         run: |

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -22,9 +22,7 @@ jobs:
           - arm64-darwin
           - arm-linux
           - aarch64-linux
-        include:
-          - platform: jruby
-            tag: jruby
+          - jruby
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -43,7 +43,7 @@ jobs:
         run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "rcd_image_version=#{RakeCompilerDock::IMAGE_VERSION}"' >> $GITHUB_OUTPUT
       - name: Build docker image
         env:
-          DOCKERHUB_USER: rake-compiler
+          CONTAINER_REGISTRY: phony-registry
           RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load
         run: |
           docker buildx create --driver docker-container --use
@@ -57,7 +57,7 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
       - env:
-          OLD_TAG: rake-compiler/rake-compiler-dock-${{matrix.tag || format('mri-{0}', matrix.platform)}}:${{steps.rcd_image_version.outputs.rcd_image_version}}
+          OLD_TAG: phony-registry/rake-compiler-dock-${{matrix.tag || format('mri-{0}', matrix.platform)}}:${{steps.rcd_image_version.outputs.rcd_image_version}}
           NEW_TAG: ghcr.io/rake-compiler/rake-compiler-dock-snapshot:${{matrix.platform}}
         run: |
           docker images

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -39,11 +39,18 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
-      - id: rcd_image_version
-        run: bundle exec ruby -e 'require "rake_compiler_dock"; puts "rcd_image_version=#{RakeCompilerDock::IMAGE_VERSION}"' >> $GITHUB_OUTPUT
+      - id: rcd_config
+        run: |
+          bundle exec ruby -e ' \
+            require "rake_compiler_dock"; \
+            print "image_name="; \
+            puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}})); \
+            print "snapshot_name="; \
+            puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}}), :version => %q(snapshot)); \
+          ' | tee -a $GITHUB_OUTPUT
+
       - name: Build docker image
         env:
-          CONTAINER_REGISTRY: phony-registry
           RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new --load
         run: |
           docker buildx create --driver docker-container --use
@@ -56,10 +63,7 @@ jobs:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - env:
-          OLD_TAG: phony-registry/rake-compiler-dock-${{matrix.tag || format('mri-{0}', matrix.platform)}}:${{steps.rcd_image_version.outputs.rcd_image_version}}
-          NEW_TAG: ghcr.io/rake-compiler/rake-compiler-dock-snapshot:${{matrix.platform}}
-        run: |
+      - run: |
           docker images
-          docker tag ${OLD_TAG} ${NEW_TAG}
-          docker push ${NEW_TAG}
+          docker tag ${{steps.rcd_config.outputs.image_name}} ${{steps.rcd_config.outputs.snapshot_name}}
+          docker push ${{steps.rcd_config.outputs.snapshot_name}}

--- a/History.md
+++ b/History.md
@@ -9,6 +9,17 @@
 * Ensure autoconf is installed in the base iamges.
 * Start publishing snapshots to ghcr.io
 * Bump JRuby to 9.4.0.0
+* Move docker images to ghcr.io/rake-compiler:
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-jruby`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-aarch64-linux`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-arm-linux`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-arm64-darwin`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x64-mingw-ucrt`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x64-mingw32`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86-linux`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86-mingw32`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86_64-darwin`
+  * `ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.0-mri-x86_64-linux`
 
 
 1.2.2 / 2022-06-27

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ jobs:
     name: "native-gem"
     runs-on: ubuntu-latest
     container:
-      image: "larskanis/rake-compiler-dock-mri-x86_64-linux:1.2.1"
+      image: "ghcr.io/rake-compiler/rake-compiler-dock-image:1.2.2-mri-x86_64-linux"
     steps:
       - uses: actions/checkout@v2
       - run: bundle install && bundle exec rake gem:x86_64-linux:rcd
@@ -242,7 +242,7 @@ The following variables are recognized by rake-compiler-dock:
     Must be a space separated list out of `x86-mingw32`, `x64-mingw-ucrt`, `x64-mingw32`, `x86-linux`, `x86_64-linux`, `arm-linux`, `aarch64-linux`, `x86_64-darwin` and `arm64-darwin`.
     It is ignored when `rubyvm` is set to `:jruby`.
 * `RCD_IMAGE` - The docker image that is downloaded and started.
-    Defaults to "larskanis/rake-compiler-dock:IMAGE_VERSION" with an image version that is determined by the gem version.
+    Defaults to "ghcr.io/rake-compiler/rake-compiler-dock-image:IMAGE_VERSION-PLATFORM" with an image version that is determined by the gem version.
 
 The following variables are passed through to the docker container without modification:
 

--- a/README.md
+++ b/README.md
@@ -221,11 +221,9 @@ For an example of rake tasks that support this style of invocation, visit https:
 
 ### Living on the edge: using weekly snapshots
 
-OCI images snapshotted from `master` are published weekly to Github Container Registry:
+OCI images snapshotted from `master` are published weekly to Github Container Registry with the string "snapshot" in place of the version number in the tag name, e.g.:
 
-> https://github.com/rake-compiler/rake-compiler-dock/pkgs/container/rake-compiler-dock-snapshot
-
-The images are named `ghcr.io/rake-compiler/rake-compiler-dock-snapshot` and are tagged with the platform name (e.g., `ghcr.io/rake-compiler/rake-compiler-dock-snapshot:x86_64-linux`.
+- `ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86_64-linux`
 
 These images are intended for integration testing. They may not work properly and should not be considered production ready.
 

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ end
 
 desc "Run tests"
 task :test do
-  sh "ruby -w -W2 -I. -Ilib -e \"#{Dir["test/test_*.rb"].map{|f| "require '#{f}';"}.join}\" -- -v"
+  sh %Q{ruby -w -W2 -I. -Ilib -e "#{Dir["test/test_*.rb"].map{|f| "require '#{f}';"}.join}" -- -v #{ENV['TESTOPTS']}}
 end
 
 desc "Update predefined_user_group.rb"

--- a/lib/rake_compiler_dock/starter.rb
+++ b/lib/rake_compiler_dock/starter.rb
@@ -178,6 +178,7 @@ module RakeCompilerDock
       end
 
       def container_rubyvm(options={})
+        return "jruby" if options[:platform] == "jruby"
         options.fetch(:rubyvm) { ENV['RCD_RUBYVM'] } || "mri"
       end
 

--- a/lib/rake_compiler_dock/starter.rb
+++ b/lib/rake_compiler_dock/starter.rb
@@ -174,7 +174,7 @@ module RakeCompilerDock
       end
 
       def container_registry
-        ENV['CONTAINER_REGISTRY'] || "larskanis"
+        ENV['CONTAINER_REGISTRY'] || "ghcr.io/rake-compiler"
       end
 
       def container_rubyvm(options={})

--- a/lib/rake_compiler_dock/starter.rb
+++ b/lib/rake_compiler_dock/starter.rb
@@ -164,11 +164,11 @@ module RakeCompilerDock
           image_name = ENV['RCD_IMAGE'] || ENV['RAKE_COMPILER_DOCK_IMAGE']
           return image_name unless image_name.nil?
 
-          "%s/rake-compiler-dock-%s%s:%s" % [
+          "%s/rake-compiler-dock-image:%s-%s%s" % [
             container_registry,
+            IMAGE_VERSION,
             container_rubyvm(options),
             container_jrubyvm?(options) ? "" : "-#{options.fetch(:platform)}",
-            IMAGE_VERSION,
           ]
         end
       end

--- a/lib/rake_compiler_dock/starter.rb
+++ b/lib/rake_compiler_dock/starter.rb
@@ -166,7 +166,7 @@ module RakeCompilerDock
 
           "%s/rake-compiler-dock-image:%s-%s%s" % [
             container_registry,
-            IMAGE_VERSION,
+            options.fetch(:version) { IMAGE_VERSION },
             container_rubyvm(options),
             container_jrubyvm?(options) ? "" : "-#{options.fetch(:platform)}",
           ]

--- a/test/test_environment_variables.rb
+++ b/test/test_environment_variables.rb
@@ -9,11 +9,12 @@ end
 class TestEnvironmentVariables
   module Common
     TEST_PLATFORM = ENV["TEST_PLATFORM"] || "x64-mingw-ucrt"
-    DOCKERHUB_USER = ENV['DOCKERHUB_USER'] || "larskanis"
-
     IS_JRUBY = TEST_PLATFORM.to_s == "jruby"
-    platform = IS_JRUBY ? "jruby" : "mri-#{TEST_PLATFORM}"
-    TEST_IMAGE_NAME = "#{DOCKERHUB_USER}/rake-compiler-dock-#{platform}:#{RakeCompilerDock::IMAGE_VERSION}"
+    TEST_IMAGE_NAME = if IS_JRUBY
+      RakeCompilerDock::Starter.container_image_name(rubyvm: "jruby")
+    else
+      RakeCompilerDock::Starter.container_image_name(platform: TEST_PLATFORM)
+    end
 
     def rcd_env
       self.class.instance_variable_get("@rcd_env") || begin

--- a/test/test_starter.rb
+++ b/test/test_starter.rb
@@ -59,6 +59,12 @@ class TestStarter < Test::Unit::TestCase
       Starter.container_image_name({:rubyvm => "jruby"}),
     )
 
+    # jruby platform arg
+    assert_equal(
+      "ghcr.io/rake-compiler/rake-compiler-dock-image:#{IMAGE_VERSION}-jruby",
+      Starter.container_image_name({:platform => "jruby"}),
+    )
+
     # container registry env var
     with_env({"CONTAINER_REGISTRY" => "registry-value"}) do
       assert_equal(
@@ -98,11 +104,16 @@ class TestStarter < Test::Unit::TestCase
     with_env({"RCD_RUBYVM" => "env-var-value"}) do
       assert_equal("option-value", Starter.container_rubyvm({:rubyvm => "option-value"}))
     end
+
+    # with jruby platform option
+    assert_equal("jruby", Starter.container_rubyvm({:platform => "jruby"}))
   end
 
   def test_container_jrubyvm?
     assert(Starter.container_jrubyvm?({:rubyvm => "jruby"}))
+    assert(Starter.container_jrubyvm?({:platform => "jruby"}))
     refute(Starter.container_jrubyvm?({:rubyvm => "mri"}))
+    refute(Starter.container_jrubyvm?({:platform => "x86_64-linux"}))
   end
 
   def test_platforms

--- a/test/test_starter.rb
+++ b/test/test_starter.rb
@@ -49,13 +49,13 @@ class TestStarter < Test::Unit::TestCase
 
     # mri platform arg
     assert_equal(
-      "larskanis/rake-compiler-dock-mri-platform-option-value:#{IMAGE_VERSION}",
+      "ghcr.io/rake-compiler/rake-compiler-dock-mri-platform-option-value:#{IMAGE_VERSION}",
       Starter.container_image_name({:platform => "platform-option-value"}),
     )
 
     # jruby rubyvm arg
     assert_equal(
-      "larskanis/rake-compiler-dock-jruby:#{IMAGE_VERSION}",
+      "ghcr.io/rake-compiler/rake-compiler-dock-jruby:#{IMAGE_VERSION}",
       Starter.container_image_name({:rubyvm => "jruby"}),
     )
 
@@ -69,7 +69,7 @@ class TestStarter < Test::Unit::TestCase
   end
 
   def test_container_registry
-    assert_equal("larskanis", Starter.container_registry)
+    assert_equal("ghcr.io/rake-compiler", Starter.container_registry)
 
     with_env({"CONTAINER_REGISTRY" => "env-var-value"}) do
       assert_equal("env-var-value", Starter.container_registry)

--- a/test/test_starter.rb
+++ b/test/test_starter.rb
@@ -49,20 +49,20 @@ class TestStarter < Test::Unit::TestCase
 
     # mri platform arg
     assert_equal(
-      "ghcr.io/rake-compiler/rake-compiler-dock-mri-platform-option-value:#{IMAGE_VERSION}",
+      "ghcr.io/rake-compiler/rake-compiler-dock-image:#{IMAGE_VERSION}-mri-platform-option-value",
       Starter.container_image_name({:platform => "platform-option-value"}),
     )
 
     # jruby rubyvm arg
     assert_equal(
-      "ghcr.io/rake-compiler/rake-compiler-dock-jruby:#{IMAGE_VERSION}",
+      "ghcr.io/rake-compiler/rake-compiler-dock-image:#{IMAGE_VERSION}-jruby",
       Starter.container_image_name({:rubyvm => "jruby"}),
     )
 
     # container registry env var
     with_env({"CONTAINER_REGISTRY" => "registry-value"}) do
       assert_equal(
-        "registry-value/rake-compiler-dock-mri-x86_64-darwin:#{IMAGE_VERSION}",
+        "registry-value/rake-compiler-dock-image:#{IMAGE_VERSION}-mri-x86_64-darwin",
         Starter.container_image_name({:platform => "x86_64-darwin"}),
       )
     end

--- a/test/test_starter.rb
+++ b/test/test_starter.rb
@@ -66,6 +66,12 @@ class TestStarter < Test::Unit::TestCase
         Starter.container_image_name({:platform => "x86_64-darwin"}),
       )
     end
+
+    # snapshots
+    assert_equal(
+      "ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86_64-darwin",
+      Starter.container_image_name({:platform =>"x86_64-darwin", :version => "snapshot"}),
+    )
   end
 
   def test_container_registry


### PR DESCRIPTION
See context from #71 and #87 

This PR moves from dockerhub `larskanis` account to the github registry for the rake-compiler org. It keeps support for the `DOCKERHUB_USER` environment variable but also supports an env var with a more appropriate name, `DOCKER_REGISTRY`.

@larskanis Would love your feedback on this!