### PR TITLE
ParallelDockerBuild: Use hashed file names to shorten then

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require "rake_compiler_dock"
 require_relative "build/gem_helper"
 require_relative "build/parallel_docker_build"
 
+CLEAN.include("tmp")
+
 RakeCompilerDock::GemHelper.install_tasks
 
 platforms = [

--- a/build/parallel_docker_build.rb
+++ b/build/parallel_docker_build.rb
@@ -1,5 +1,6 @@
 require "fileutils"
 require "rake"
+require "digest/sha1"
 
 module RakeCompilerDock
   class << self
@@ -92,7 +93,7 @@ module RakeCompilerDock
     # This also adds dependant intermediate tasks as prerequisites.
     def define_common_tasks(vcs, workdir, task_prefix, plines=[])
       vcs.map do |files, (lines, nvcs)|
-        fn = "#{task_prefix}#{files.join}"
+        fn = "#{task_prefix}#{Digest::SHA1.hexdigest(files.join)}"
         File.write(File.join(workdir, fn), (plines + lines).join)
         task fn do
           docker_build(fn, workdir)


### PR DESCRIPTION
With the many images we now have, the file names of the common parts of docker images have grown to 220 characters. This already exceeds the maximum length of file names of some file systems (ecryptfs). Using a hash is less expressive, but usually the name of these files is just an internal thing.

Also add the tmp directory with these common-* files to "rake clean".