### PR TITLE
dev: make sure the buildx cache is in an external directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 /Dockerfile.mri.x86_64-linux
 /Gemfile.lock
 /_yardoc/
-/cache/
 /coverage/
 /doc/
 /pkg/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,4 @@ docker buildx create --use --driver=docker-container
 bundle exec rake build
 ```
 
+The cache will be generated in a sibling directory ("../rake-compiler-dock-cache") to avoid including the cache in the build context.

--- a/build/parallel_docker_build.rb
+++ b/build/parallel_docker_build.rb
@@ -7,7 +7,7 @@ module RakeCompilerDock
       cmd = if ENV['RCD_USE_BUILDX_CACHE']
         if platform
           cache_version = RakeCompilerDock::IMAGE_VERSION.split(".").take(2).join(".")
-          cache = File.join("cache", cache_version, platform)
+          cache = File.join("..", "rake-compiler-dock-cache", "cache", cache_version, platform)
           "docker buildx build --cache-to=type=local,dest=#{cache},mode=max --cache-from=type=local,src=#{cache} --load"
         else
           return nil


### PR DESCRIPTION
Previous commit bbcf9fe1 introduced support for buildx backend caching. However, it put the cache in the PWD, which is inconvenient because then it's included as part of the `docker build` context.

This PR updates the cache to be in an external directory.