### PR TITLE
dev: dockerignore cache files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+cache/
+cache*.tar


### PR DESCRIPTION
Previous commit bbcf9fe1 introduced support for buildx backend caching. However, it put the cache in the PWD, which is inconvenient because then it's included as part of the `docker build` context.

This change dockerignores those files.