### PR TITLE
feat: update ruby 3.3 support to use 3.3.0

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -142,7 +142,7 @@ RUN bash -c " \
 axrubies = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1.0+ is platform x64-mingw-ucrt
-    ["3.3.0-rc1:3.2.0:3.1.0", "3.1.3"],
+    ["3.3.0:3.2.0:3.1.0", "3.1.3"],
   ]
 elsif platform =~ /x64-mingw32/
   [
@@ -153,7 +153,7 @@ elsif platform =~ /x64-mingw32/
 else
   [
     ["2.6.0:2.5.0:2.4.0", "2.5.9"],
-    ["3.3.0-rc1:3.2.0:3.1.0:3.0.0:2.7.0", "3.1.3"],
+    ["3.3.0:3.2.0:3.1.0:3.0.0:2.7.0", "3.1.3"],
   ]
 end
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+1.4.next / unreleased
+---------------------
+
+* Add Ruby 3.3.0 cross-compilation support. (@stanhu)
+
 1.4.0.rc2 / 2023-12-12
 ---------------------
 


### PR DESCRIPTION
Ruby 3.3.0 was released today:
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/