### PR TITLE
ci: add coverage for ruby 3.3.0 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "3.2"
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Build docker image
@@ -120,7 +120,8 @@ jobs:
         os:
           - ubuntu
         ruby:
-          - "head" # 3.3
+          - "head"
+          - "3.3"
           - "3.2"
           - "3.1"
           - "3.0"
@@ -158,6 +159,7 @@ jobs:
           - ubuntu
         ruby:
           - "head" # 3.3
+          - "3.3"
           - "3.2"
           - "3.1"
           - "3.0"
@@ -182,6 +184,9 @@ jobs:
             ruby: "3.2"
             platform: x64-mingw-ucrt
           - os: windows
+            ruby: "3.3"
+            platform: x64-mingw-ucrt
+          - os: windows
             ruby: "head"
             platform: x64-mingw-ucrt
         exclude:
@@ -189,6 +194,8 @@ jobs:
             ruby: "3.1"
           - os: windows
             ruby: "3.2"
+          - os: windows
+            ruby: "3.3"
           - os: windows
             ruby: "head"
 
@@ -220,7 +227,8 @@ jobs:
         os:
           - windows
         ruby:
-          - "head" # 3.3
+          - "head"
+          - "3.3"
           - "3.2"
           - "3.1"
           - "3.0"
@@ -238,6 +246,9 @@ jobs:
             ruby: "3.2"
             platform: x64-mingw-ucrt
           - os: windows
+            ruby: "3.3"
+            platform: x64-mingw-ucrt
+          - os: windows
             ruby: "head"
             platform: x64-mingw-ucrt
         exclude:
@@ -245,6 +256,8 @@ jobs:
             ruby: "3.1"
           - os: windows
             ruby: "3.2"
+          - os: windows
+            ruby: "3.3"
           - os: windows
             ruby: "head"
 


### PR DESCRIPTION
This will probably fail until/unless `ruby/setup-ruby` supports 3.3.0