### PR TITLE
ci: remove windows "head" from native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
         os:
           - ubuntu
         ruby:
-          - "head"
           - "3.3"
           - "3.2"
           - "3.1"
@@ -158,7 +157,6 @@ jobs:
           - macos
           - ubuntu
         ruby:
-          - "head" # 3.3
           - "3.3"
           - "3.2"
           - "3.1"
@@ -186,9 +184,6 @@ jobs:
           - os: windows
             ruby: "3.3"
             platform: x64-mingw-ucrt
-          - os: windows
-            ruby: "head"
-            platform: x64-mingw-ucrt
         exclude:
           - os: windows
             ruby: "3.1"
@@ -196,8 +191,6 @@ jobs:
             ruby: "3.2"
           - os: windows
             ruby: "3.3"
-          - os: windows
-            ruby: "head"
 
     runs-on: ${{ matrix.os }}-latest
     steps:
@@ -227,7 +220,6 @@ jobs:
         os:
           - windows
         ruby:
-          - "head"
           - "3.3"
           - "3.2"
           - "3.1"
@@ -248,9 +240,6 @@ jobs:
           - os: windows
             ruby: "3.3"
             platform: x64-mingw-ucrt
-          - os: windows
-            ruby: "head"
-            platform: x64-mingw-ucrt
         exclude:
           - os: windows
             ruby: "3.1"
@@ -258,8 +247,6 @@ jobs:
             ruby: "3.2"
           - os: windows
             ruby: "3.3"
-          - os: windows
-            ruby: "head"
 
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
because that's now 3.4-derived and so is failing the version checks