### PR TITLE
ci: add musl images to the weekly snapshots

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -14,15 +14,19 @@ jobs:
       matrix:
         platform:
           - aarch64-linux-gnu
+          - aarch64-linux-musl
           - arm-linux-gnu
+          - arm-linux-musl
           - arm64-darwin
+          - jruby
           - x64-mingw-ucrt
           - x64-mingw32
           - x86-linux-gnu
+          - x86-linux-musl
           - x86-mingw32
           - x86_64-darwin
           - x86_64-linux-gnu
-          - jruby
+          - x86_64-linux-musl
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I forgot to add this to #111 to generate weekly snapshots of the musl images.