### PR TITLE
Update pkg-config in manylinux build images to 0.29.2

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -226,7 +226,7 @@ RUN mv /opt/osxcross/target/bin/<%= target %>-strip /opt/osxcross/target/bin/<%=
 RUN echo "export PATH=\$DEVTOOLSET_ROOTPATH/usr/bin:\$PATH" >> /etc/rubybashrc
 
 # Add prefixed versions of compiler tools
-RUN for f in addr2line gcc gcov-tool ranlib ar dwp gcc-ranlib nm readelf as elfedit gcc-ar gprof objcopy size c++filt g++ gcov ld objdump strings cpp gcc-nm pkg-config strip ; do ln -sf $DEVTOOLSET_ROOTPATH/usr/bin/$f $DEVTOOLSET_ROOTPATH/usr/bin/<%= target %>-$f ; done
+RUN for f in addr2line gcc gcov-tool ranlib ar dwp gcc-ranlib nm readelf as elfedit gcc-ar gprof objcopy size c++filt g++ gcov ld objdump strings cpp gcc-nm strip ; do ln -sf $DEVTOOLSET_ROOTPATH/usr/bin/$f $DEVTOOLSET_ROOTPATH/usr/bin/<%= target %>-$f ; done
 
 # Use builtin functions of newer gcc to avoid linker issues on Musl based Linux
 # TODO: remove in v1.6.0 once musl builds have been out for full minor release cycle, see 864be5b2

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -233,6 +233,10 @@ RUN for f in addr2line gcc gcov-tool ranlib ar dwp gcc-ranlib nm readelf as elfe
 COPY build/math_h.patch /root/
 RUN cd /usr/include/ && \
     patch -p1 < /root/math_h.patch
+
+# Update pkg-config because the distro ships 0.27.1 which is old and has bugs and performance issues.
+COPY build/mk_pkg_config.sh /root/
+RUN /root/mk_pkg_config.sh
 <% end %>
 
 <% if platform =~ /arm64-darwin/ %>

--- a/build/mk_pkg_config.sh
+++ b/build/mk_pkg_config.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -x
+
+# sha256 from https://lists.freedesktop.org/archives/pkg-config/2017-March/001084.html
+TARFILE=pkg-config-0.29.2.tar.gz
+DIR=pkg-config-0.29.2
+CHECKSUM=6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
+
+cd /tmp
+
+wget https://pkgconfig.freedesktop.org/releases/${TARFILE}
+sha256sum ${TARFILE} | grep "${CHECKSUM}"
+
+tar -xzvf ${TARFILE}
+cd $DIR
+
+./configure --prefix=/usr/local
+make install
+
+pkg-config --version
+echo "OK"

--- a/lib/rake_compiler_dock/version.rb
+++ b/lib/rake_compiler_dock/version.rb
@@ -1,4 +1,4 @@
 module RakeCompilerDock
-  VERSION = "1.5.0"
-  IMAGE_VERSION = "1.5.0"
+  VERSION = "1.5.1.dev"
+  IMAGE_VERSION = "1.5.1.dev"
 end


### PR DESCRIPTION
Addresses concerns from #121 

Note that:

- the original pkg-config is in `/usr/bin`
- this patch installs the new pkg-config into `/usr/local/bin`
- and `/usr/local/bin` is ahead of `/usr/bin` in `$PATH` so the new one should be used by default

If this works, then I'll add some documentation around it.
