### PR TITLE
update ruby 3.3 support from 3.3.0-rc1 to 3.3.5

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -110,7 +110,7 @@ RUN sudo mkdir -p /usr/local/rake-compiler && \
 xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1.0+ is platform x64-mingw-ucrt
-    ["3.3.0-rc1:3.2.0:3.1.0", "3.1.3"],
+    ["3.3.5:3.2.0:3.1.0", "3.1.3"],
   ]
 elsif platform =~ /x64-mingw32/
   [
@@ -121,7 +121,7 @@ elsif platform =~ /x64-mingw32/
 else
   [
     ["2.6.0:2.5.0:2.4.0", "2.5.9"],
-    ["3.3.0-rc1:3.2.0:3.1.0:3.0.0:2.7.0", "3.1.3"],
+    ["3.3.5:3.2.0:3.1.0:3.0.0:2.7.0", "3.1.3"],
   ]
 end
 
@@ -217,6 +217,6 @@ COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
 RUN bash -c "rbenv global 3.1.3"
 
-ENV RUBY_CC_VERSION=3.3.0:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0:2.5.0:2.4.0
+ENV RUBY_CC_VERSION=3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0:2.5.0:2.4.0
 
 CMD bash

--- a/History.md
+++ b/History.md
@@ -9,9 +9,14 @@
 Changed the base image of `x86_64-linux-gnu` and `x86-linux-gnu` images from `manylinux2014` to `ubuntu:20.04`, unifying all the builds are the same base image. See https://github.com/rake-compiler/rake-compiler-dock/issues/122 for more context.
 
 
-### Features
+### Added
 
 - Add support for the `SOURCE_DATE_EPOCH` environment variable, which can be used to create reproducible builds. #128 by @segiddins)
+
+
+### Changed
+
+- Move Ruby 3.3 support from 3.3.0-rc1 to 3.3.5. Note that the 3.3.x releases are not usable until 3.3.5 because of https://bugs.ruby-lang.org/issues/20088.
 
 
 ## 1.5.2 / 2024-07-30


### PR DESCRIPTION
Note that 3.3.0 is not usable because of
https://bugs.ruby-lang.org/issues/20088.

See #112 for more context.