### PR TITLE
Update manylinux2014 base images with version patched for EOL

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -1,8 +1,8 @@
 <%
 image = case platform
-  when /x86_64-linux-gnu/ then "quay.io/pypa/manylinux2014_x86_64"
-  when /x86-linux-gnu/ then "quay.io/pypa/manylinux2014_i686"
-  else "ubuntu:20.04"
+  when /x86_64-linux-gnu/ then "quay.io/pypa/manylinux2014_x86_64:latest@sha256:04bffb03cd21d7945c327f67745897adddeb1d6635d79ba98811e7526460f2e0"
+  when /x86-linux-gnu/ then "quay.io/pypa/manylinux2014_i686:latest@sha256:516a28921cf4d2544be8278764e3e5d33da0a4b4e26bbbb523a5702b96b329b0"
+  else "docker.io/library/ubuntu:20.04@sha256:80ef4a44043dec4490506e6cc4289eeda2d106a70148b74b5ae91ee670e9c35d"
 end
 manylinux = !!(image =~ /manylinux/)
 %>


### PR DESCRIPTION
With CentOS 7 becoming EOL as of 2024-06-30, `yum` will no longer work in the `x86_64-linux-gnu` and `x86-linux-gnu` images shipped with v1.5.1 and earlier.

In this commit, we update the `manylinux2014` base image for the `x86_64-linux-gnu` and `x86-linux-gnu` images to point at a version patched by `pypa` to use valid yum mirrors. See
https://github.com/pypa/manylinux/pull/1628 for more information.

Note that the ubuntu image version is the same from v1.5.0 and v1.5.1.