### PR TITLE
Pass SOURCE_DATE_EPOCH to docker run

### DIFF
--- a/lib/rake_compiler_dock/starter.rb
+++ b/lib/rake_compiler_dock/starter.rb
@@ -66,6 +66,7 @@ module RakeCompilerDock
               "-e", "USER=#{user}",
               "-e", "GROUP=#{group}",
               "-e", "GEM_PRIVATE_KEY_PASSPHRASE",
+              "-e", "SOURCE_DATE_EPOCH",
               "-e", "ftp_proxy",
               "-e", "http_proxy",
               "-e", "https_proxy",


### PR DESCRIPTION
See https://github.com/rubygems/rubygems/pull/2289, it helps make gem builds reproducible