### PR TITLE
ci: pin rubygems to 3.5 for ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,7 @@ jobs:
         ruby: ["3.4.0-rc1", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "2.4"]
         include:
           # declare rubygems for each ruby version
+          - { ruby: "3.0", rubygems: "3.5.23" }
           - { ruby: "2.7", rubygems: "3.4.22" }
           - { ruby: "2.6", rubygems: "3.4.22" }
           - { ruby: "2.5", rubygems: "3.3.26" }
@@ -216,6 +217,7 @@ jobs:
         ruby: ["3.4.0-rc1", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "2.4"]
         include:
           # declare rubygems for each ruby version
+          - { ruby: "3.0", rubygems: "3.5.23" }
           - { ruby: "2.7", rubygems: "3.4.22" }
           - { ruby: "2.6", rubygems: "3.4.22" }
           - { ruby: "2.5", rubygems: "3.3.26" }


### PR DESCRIPTION
Example failure: https://github.com/rake-compiler/rake-compiler-dock/actions/runs/12386884507/job/34575544396

```
ERROR:  Error installing rubygems-update:
	rubygems-update-3.6.1 requires Ruby version >= 3.1.0. The current ruby version is 3.0.7.220.
```