### PR TITLE
dep: bump all rubies' patch level

### DIFF
--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -50,7 +50,9 @@ RUN bash -c " \
         rbenv shell \$v && \
         gem install rake-compiler -v1.2.9 && \
         cd ${RBENV_ROOT}/versions/\$v/lib/ruby/gems/*/gems/rake-compiler-1.2.9 && \
-        patch -p1 < /home/rubyuser/patches/rake-compiler-1.2.9/*.patch ; \
+        for patch in /home/rubyuser/patches/rake-compiler-1.2.9/*.patch ; do \
+          patch -p1 < \$patch ; \
+        done \
       done \
     "
 

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -167,12 +167,15 @@ RUN find /usr/local/rake-compiler/ruby -name lib*-ruby*.dll.a | while read f ; d
 RUN find /usr/local/rake-compiler/ruby -name rbconfig.rb | while read f ; do sed -i 's/-lcrypt//' $f ; done
 
 <% if platform =~ /darwin/ %>
-# ruby-3.2+ on darwin links with `-bundle_loader`,
-# - see https://github.com/rake-compiler/rake-compiler-dock/issues/87
-# - note that we do this for "3.[2-9].*" to match rubies 3.2 and later
-# - and we use a "*" on the end instead of a digit to match prereleases like "3.3.0+0"
-RUN find /usr/local/rake-compiler/ruby/*/*/lib/ruby/3.[2-9].* -name rbconfig.rb | \
-    while read f ; do sed -i 's/\["EXTDLDFLAGS"\] = "/&-Wl,-flat_namespace /' $f ; done
+# for rubies which use `-bundle_loader` on darwin
+# - the upstream change: https://github.com/ruby/ruby/pull/6193
+# - how we got to this solution: https://github.com/rake-compiler/rake-compiler-dock/issues/87
+#
+# note that ruby/ruby#6193 was backported to 2.7.7, 3.0.5, and 3.1.3
+# - see https://github.com/rake-compiler/rake-compiler-dock/issues/134 for more notes
+RUN find /usr/local/rake-compiler/ruby/*/*/lib/ruby -name rbconfig.rb | while read f ; do \
+      sed -E -i 's/(\["EXTDLDFLAGS"\] = ".*)(-bundle_loader)/\1-Wl,-flat_namespace \2/' $f ; \
+    done
 <% end %>
 
 

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -93,7 +93,9 @@ RUN bash -c " \
         rbenv shell \$v && \
         gem install rake-compiler -v1.2.9 && \
         cd ${RBENV_ROOT}/versions/\$v/lib/ruby/gems/*/gems/rake-compiler-1.2.9 && \
-        patch -p1 < /home/rubyuser/patches/rake-compiler-1.2.9/*.patch ; \
+        for patch in /home/rubyuser/patches/rake-compiler-1.2.9/*.patch ; do \
+          patch -p1 < \$patch ; \
+        done \
       done \
     "
 
@@ -113,7 +115,7 @@ RUN sudo mkdir -p /usr/local/rake-compiler && \
 xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1+ is platform x64-mingw-ucrt
-    ["3.4.1:3.3.5:3.2.6:3.1.2", "3.1.6"],
+    ["3.4.1:3.3.5:3.2.6:3.1.6", "3.1.6"],
   ]
 elsif platform =~ /x64-mingw32/
   [
@@ -124,7 +126,7 @@ elsif platform =~ /x64-mingw32/
 else
   [
     ["2.6.10:2.5.9:2.4.10", "2.5.9"],
-    ["3.4.1:3.3.5:3.2.6:3.1.2:3.0.7:2.7.8", "3.1.6"],
+    ["3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8", "3.1.6"],
   ]
 end
 
@@ -223,6 +225,6 @@ COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
 RUN bash -c "rbenv global 3.1.6"
 
-ENV RUBY_CC_VERSION=3.4.1:3.3.5:3.2.6:3.1.2:3.0.7:2.7.8:2.6.10:2.5.9:2.4.10
+ENV RUBY_CC_VERSION=3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10:2.5.9:2.4.10
 
 CMD bash

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -112,19 +112,19 @@ RUN sudo mkdir -p /usr/local/rake-compiler && \
 #
 xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
   [
-    # Rubyinstaller-3.1.0+ is platform x64-mingw-ucrt
-    ["3.4.1:3.3.5:3.2.0:3.1.0", "3.1.6"],
+    # Rubyinstaller-3.1+ is platform x64-mingw-ucrt
+    ["3.4.1:3.3.5:3.2.6:3.1.2", "3.1.6"],
   ]
 elsif platform =~ /x64-mingw32/
   [
-    # Rubyinstaller prior to 3.1.0 is platform x64-mingw32
-    ["2.6.0:2.5.0:2.4.0", "2.5.9"],
-    ["3.0.0:2.7.0", "3.1.6"],
+    # Rubyinstaller prior to 3.1 is platform x64-mingw32
+    ["2.6.10:2.5.9:2.4.10", "2.5.9"],
+    ["3.0.7:2.7.8", "3.1.6"],
   ]
 else
   [
-    ["2.6.0:2.5.0:2.4.0", "2.5.9"],
-    ["3.4.1:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0", "3.1.6"],
+    ["2.6.10:2.5.9:2.4.10", "2.5.9"],
+    ["3.4.1:3.3.5:3.2.6:3.1.2:3.0.7:2.7.8", "3.1.6"],
   ]
 end
 
@@ -220,6 +220,6 @@ COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
 RUN bash -c "rbenv global 3.1.6"
 
-ENV RUBY_CC_VERSION=3.4.1:3.3.5:3.2.0:3.1.0:3.0.0:2.7.0:2.6.0:2.5.0:2.4.0
+ENV RUBY_CC_VERSION=3.4.1:3.3.5:3.2.6:3.1.2:3.0.7:2.7.8:2.6.10:2.5.9:2.4.10
 
 CMD bash

--- a/build/mk_osxcross.sh
+++ b/build/mk_osxcross.sh
@@ -27,6 +27,8 @@ rm -rf *~ build tarballs/*
 echo "export PATH=/opt/osxcross/target/bin:\$PATH" >> /etc/rubybashrc
 echo "export MACOSX_DEPLOYMENT_TARGET=10.13" >> /etc/rubybashrc
 echo "export OSXCROSS_MP_INC=1" >> /etc/rubybashrc
+echo "export OSXCROSS_PKG_CONFIG_USE_NATIVE_VARIABLES=1" >> /etc/rubybashrc
+
 
 # Add links to build tools without target version kind of:
 #   arm64-apple-darwin-clang   =>   arm64-apple-darwin20.1-clang

--- a/build/patches/rake-compiler-1.2.9/0005-build-miniruby-first.patch
+++ b/build/patches/rake-compiler-1.2.9/0005-build-miniruby-first.patch
@@ -1,0 +1,17 @@
+diff --git a/tasks/bin/cross-ruby.rake b/tasks/bin/cross-ruby.rake
+index d37ab97b..0df44b30 100644
+--- a/tasks/bin/cross-ruby.rake
++++ b/tasks/bin/cross-ruby.rake
+@@ -129,6 +129,12 @@
+ 
+     # make
+     file "#{build_dir}/ruby.exe" => ["#{build_dir}/Makefile"] do |t|
++      puts "MIKE: #{ruby_cc_version}: #{mingw_target}"
++      if ruby_cc_version.start_with?("ruby-3.1") && mingw_target =~ /darwin/
++        # for later 3.1.x releases, we need to explicitly build miniruby
++        # see https://bugs.ruby-lang.org/issues/19239
++        sh "#{MAKE} miniruby", chdir: File.dirname(t.prerequisites.first)
++      end
+       sh MAKE, chdir: File.dirname(t.prerequisites.first)
+     end
+ 


### PR DESCRIPTION
https://github.com/rake-compiler/rake-compiler-dock/issues/134 requested bumping Ruby 3.0.

Let's see what happens if we bump them all.

Bump rubies:

- 3.4.1 → 3.4.1 [^1]
- 3.3.5 → 3.3.5 [^1]
- 3.2.0 → 3.2.6
- 3.1.0 → 3.1.6
- 3.0.0 → 3.0.7
- 2.7.0 → 2.7.8
- 2.6.0 → 2.6.10
- 2.5.0 → 2.5.9
- 2.4.0 → 2.4.10

Other changes:
- set OSXCROSS_PKG_CONFIG_USE_NATIVE_VARIABLES=1 because we started running into build problems with the 3.0.x series
- on darwin, when building 3.1.x, use a patched rake-compiler to explicitly build `miniruby` to address https://bugs.ruby-lang.org/issues/19239 (this fix appeared in 3.2.0 but was not backported)

[^1]: unchanged because it's already the latest

cc @mudge