### PR TITLE
Allow using multiplatform images

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -37,12 +37,12 @@ ENV BASH_ENV=/etc/rubybashrc
 ##
 <% if platform =~ /x64-mingw-ucrt/ %>
 COPY --from=larskanis/mingw64-ucrt:20.04 \
-    /build/binutils-mingw-w64-x86-64_2.34-6ubuntu1.3+8.8_amd64.deb \
-    /build/g++-mingw-w64-x86-64_9.3.0-17ubuntu1~20.04+22~exp1ubuntu4_amd64.deb \
-    /build/gcc-mingw-w64-base_9.3.0-17ubuntu1~20.04+22~exp1ubuntu4_amd64.deb \
-    /build/gcc-mingw-w64-x86-64_9.3.0-17ubuntu1~20.04+22~exp1ubuntu4_amd64.deb \
-    /build/mingw-w64-common_7.0.0-2_all.deb \
-    /build/mingw-w64-x86-64-dev_7.0.0-2_all.deb \
+    /build/binutils-mingw-w64-x86-64_*.deb \
+    /build/g++-mingw-w64-x86-64_*.deb \
+    /build/gcc-mingw-w64-base_*.deb \
+    /build/gcc-mingw-w64-x86-64_*.deb \
+    /build/mingw-w64-common_*.deb \
+    /build/mingw-w64-x86-64-dev_*.deb \
     /debs/
 RUN dpkg -i /debs/*.deb
 
@@ -57,6 +57,7 @@ if platform =~ /darwin/            %> clang python lzma-dev libxml2-dev libssl-d
 if platform =~ /aarch64-linux-gnu/ %> gcc-aarch64-linux-gnu g++-aarch64-linux-gnu <% end %><%
 if platform =~ /arm-linux-gnu/     %> gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf <% end %><%
 if platform =~ /x86-linux-gnu/     %> gcc-i686-linux-gnu g++-i686-linux-gnu <% end %><%
+if platform =~ /x86_64-linux-gnu/  %> gcc-x86-64-linux-gnu g++-x86-64-linux-gnu <% end %><%
 if platform =~ /x86-mingw32/       %> gcc-mingw-w64-i686 g++-mingw-w64-i686 <% end %><%
 if platform =~ /x64-mingw32/       %> gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 <% end %> && \
     rm -rf /var/lib/apt/lists/*
@@ -148,7 +149,7 @@ RUN bash -c " \
 RUN find /usr/local/rake-compiler/ruby/*linux*/ -name libruby.so | xargs rm
 RUN find /usr/local/rake-compiler/ruby/*linux*/ -name libruby-static.a | while read f ; do cp $f `echo $f | sed s/-static//` ; done
 RUN find /usr/local/rake-compiler/ruby/*linux*/ -name libruby.a | while read f ; do ar t $f | xargs ar d $f ; done
-RUN find /usr/local/rake-compiler/ruby/*linux*/ -name mkmf.rb | while read f ; do sed -i ':a;N;$!ba;s/TRY_LINK = [^\n]*\n[^\n]*\n[^\n]*LOCAL_LIBS)/& -lruby-static -lpthread -lrt -ldl <% if platform =~ /x86_64/ %> -lcrypt <% if platform !~ /musl/ %> -lz <% end %> <% end %>/' $f ; done
+RUN find /usr/local/rake-compiler/ruby/*linux*/ -name mkmf.rb | while read f ; do sed -i ':a;N;$!ba;s/TRY_LINK = [^\n]*\n[^\n]*\n[^\n]*LOCAL_LIBS)/& -lruby-static -lpthread -lrt -ldl/' $f ; done
 <% end %>
 
 <% if platform =~ /mingw/ %>

--- a/build/mk_osxcross.sh
+++ b/build/mk_osxcross.sh
@@ -13,7 +13,7 @@ set -x
 curl -L -o MacOSX11.1.sdk.tar.xz https://github.com/larskanis/MacOSX-SDKs/releases/download/11.1/MacOSX11.1.sdk.tar.xz
 tar -xf MacOSX11.1.sdk.tar.xz -C .
 cp -rf /usr/lib/llvm-10/include/c++ MacOSX11.1.sdk/usr/include/c++
-cp -rf /usr/include/x86_64-linux-gnu/c++/9/bits/ MacOSX11.1.sdk/usr/include/c++/v1/bits
+cp -rf /usr/include/*-linux-gnu/c++/9/bits/ MacOSX11.1.sdk/usr/include/c++/v1/bits
 tar -cJf MacOSX11.1.sdk.tar.xz MacOSX11.1.sdk
 
 set +x

--- a/build/patches2/rake-compiler-1.2.5/0004-Enable-build-of-static-libruby.patch
+++ b/build/patches2/rake-compiler-1.2.5/0004-Enable-build-of-static-libruby.patch
@@ -2,13 +2,16 @@ diff --git a/tasks/bin/cross-ruby.rake b/tasks/bin/cross-ruby.rake
 index 8317a2a3..8ed21718 100644
 --- a/tasks/bin/cross-ruby.rake
 +++ b/tasks/bin/cross-ruby.rake
-@@ -116,11 +116,27 @@
+@@ -116,11 +116,30 @@
          "--host=#{mingw_host}",
          "--target=#{mingw_target}",
          "--build=#{RUBY_BUILD}",
 -        '--enable-shared',
 +        '--enable-install-static-library',
 +        '--disable-jit-support',
++        'ac_cv_lib_z_uncompress=no',
++        'ac_cv_lib_crypt_crypt=no',
++        'ac_cv_func_crypt_r=no',
          '--disable-install-doc',
          '--with-ext=',
        ]

--- a/mingw64-ucrt/Dockerfile
+++ b/mingw64-ucrt/Dockerfile
@@ -32,7 +32,7 @@ RUN cd mingw-w64-* && \
 
 # Install UCRT enabled deb-packages
 RUN dpkg -i mingw-w64-common_7.0.0-2_all.deb \
-    mingw-w64-tools_7.0.0-2_amd64.deb \
+    mingw-w64-tools_7.0.0-2_*.deb \
     mingw-w64-x86-64-dev_7.0.0-2_all.deb
 
 # Download gcc-binutils sources for mingw
@@ -51,6 +51,10 @@ RUN cd binutils-mingw-w64-* && \
 RUN apt-get source gcc-mingw-w64 && \
     cd gcc-mingw-w64-* && \
     mk-build-deps -ir -t "apt-get -o Debug::pkgProblemResolver=yes -y --no-install-recommends"
+
+# Add version based alias
+RUN ln -s `which autoconf` `which autoconf`2.69 && \
+    ln -s `which autom4te` `which autom4te`2.69
 
 # Build gcc (only C and C++) based on UCRT headers and crt
 ADD gcc-mingw-w64-*.patch ./

--- a/mingw64-ucrt/README.md
+++ b/mingw64-ucrt/README.md
@@ -1,0 +1,58 @@
+Docker image with compilers for ruby platform x64-mingw-ucrt
+------------------
+
+This Dockerfile builds compilers for Windows UCRT target.
+It takes the mingw compiler provided by Debian/Ubuntu and configures and compiles them for UCRT.
+Outputs are *.deb files of binutils, gcc and g++.
+Rake-compiler-dock reads them from this image as part of its build process for the x64-mingw-ucrt platform.
+
+The image is provided for arm64 and amd64 architectures.
+They are built by the following command:
+
+```sh
+docker buildx build . -t larskanis/mingw64-ucrt:20.04 --platform linux/arm64,linux/amd64 --push
+```
+
+
+Create builder instance for two architectures
+------------------
+
+Building with qemu emulation fails currently with a segfault, so that it must be built by a builder instance with at least one remote node for the other architecture.
+Building on native hardware is also much faster (~30 minutes) than on qemu.
+A two-nodes builder requires obviously a ARM and a Intel/AMD device.
+It can be created like this:
+
+```sh
+# Make sure the remote instance can be connected
+$ docker -H ssh://isa info
+
+# Create a new builder with the local instance
+$ docker buildx create --name isayoga
+
+# Add the remote instance
+$ docker buildx create --name isayoga --append ssh://isa
+
+# They are inactive from the start
+$ docker buildx ls
+NAME/NODE      DRIVER/ENDPOINT                   STATUS     BUILDKIT   PLATFORMS
+isayoga        docker-container
+ \_ isayoga0    \_ unix:///var/run/docker.sock   inactive
+ \_ isayoga1    \_ ssh://isa                     inactive
+default*       docker
+ \_ default     \_ default                       running    v0.13.2    linux/arm64
+
+# Bootstrap the instances
+$ docker buildx inspect --bootstrap --builder isayoga
+
+# Set the new builder as default
+$ docker buildx use isayoga
+
+# Now it should be default and in state "running"
+$ docker buildx ls
+NAME/NODE      DRIVER/ENDPOINT                   STATUS    BUILDKIT   PLATFORMS
+isayoga*       docker-container
+ \_ isayoga0    \_ unix:///var/run/docker.sock   running   v0.18.2    linux/arm64
+ \_ isayoga1    \_ ssh://isa                     running   v0.18.2    linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/386
+default        docker
+ \_ default     \_ default                       running   v0.13.2    linux/arm64
+```


### PR DESCRIPTION
These are the changes necessary to build both `linux/amd64` and `linux/arm64` docker images. This way we can provide not only images running on x86_64 but also aarch64. They run much faster on ARM based Mac and ARM based Linux systems.

On the native platform (x86_64-linux or aarch64-linux) ruby configure script finds libz and libcrypt and makes use of it in libruby.
Disabling them per `ac_cv_*` variables unifies cross builds and we can remove platform specific injection of `-lz` and `-lcrypt` into `mkmf.rb` .

The docker image for the x64-mingw-ucrt compiler `larskanis/mingw64-ucrt` needs to be rebuilt on `linux/arm64` platform, so that both arm64 and amd64 are provided. Currently the image for platform `linux/amd64` is used on `linux/arm64`, which doesn't work.

The rebuild fails on docker arm64 emulation with segmentation fault, but works flawlessly on a real arm64 device.
When it is rebuilt, the deb package versions have changed versions, which is adjusted below. So it makes sense to rebuild and push `larskanis/mingw64-ucrt` just before this PR is merged.

I didn't test whether the image build on x86_64 with `docker buildx` arm64 emulation works. Maybe they crash similar to `mingw64-ucrt`. In any case it's very slow. However I can build the `linux/arm64` images locally and push them manually.

Fixes #78