### PR TITLE
Allow gems to set `required_ruby_version = '>= 3.2.0'`

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -115,7 +115,7 @@ RUN sudo mkdir -p /usr/local/rake-compiler && \
 xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1+ is platform x64-mingw-ucrt
-    ["3.4.1:3.3.5:3.2.6:3.1.6", "3.1.6"],
+    ["3.4.1:3.3.5:3.2.6:3.1.6", "3.4.1"],
   ]
 elsif platform =~ /x64-mingw32/
   [
@@ -126,7 +126,8 @@ elsif platform =~ /x64-mingw32/
 else
   [
     ["2.6.10:2.5.9:2.4.10", "2.5.9"],
-    ["3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8", "3.1.6"],
+    ["2.7.8", "3.1.6"],
+    ["3.4.1:3.3.5:3.2.6:3.1.6:3.0.7", "3.4.1"],
   ]
 end
 

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -74,7 +74,7 @@ ENV BASH_ENV=/etc/rubybashrc
 ##
 USER rubyuser
 
-ENV RBENV_RUBIES="2.5.9 3.1.6"
+ENV RBENV_RUBIES="2.5.9 3.1.6 3.4.1"
 
 # Install the bootstrap rubies
 RUN bash -c " \
@@ -223,7 +223,7 @@ RUN echo 'source /etc/profile.d/rcd-env.sh' >> /etc/rubybashrc
 # Install sudoers configuration
 COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
-RUN bash -c "rbenv global 3.1.6"
+RUN bash -c "rbenv global 3.4.1"
 
 ENV RUBY_CC_VERSION=3.4.1:3.3.5:3.2.6:3.1.6:3.0.7:2.7.8:2.6.10:2.5.9:2.4.10
 

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -78,26 +78,26 @@ ENV RBENV_RUBIES="2.5.9 3.1.6 3.4.1"
 
 # Install the bootstrap rubies
 RUN bash -c " \
-      echo 'gem: --no-ri --no-rdoc --no-document' >> ~/.gemrc && \
-      export CFLAGS='-s -O3 -fno-fast-math -fPIC' && \
-      for v in ${RBENV_RUBIES} ; do \
-        rbenv install \$v -- --disable-install-doc ; \
-      done && \
-      find ${RBENV_ROOT} -type d -print0 | sudo xargs -0 chmod g+w \
-    "
+  echo 'gem: --no-ri --no-rdoc --no-document' >> ~/.gemrc && \
+  export CFLAGS='-s -O3 -fno-fast-math -fPIC' && \
+  for v in ${RBENV_RUBIES} ; do \
+    rbenv install \$v -- --disable-install-doc ; \
+  done && \
+  find ${RBENV_ROOT} -type d -print0 | sudo xargs -0 chmod g+w \
+"
 
 # Install rake-compiler and patch it to build and install static libraries for Linux rubies
 COPY build/patches /home/rubyuser/patches
 RUN bash -c " \
-      for v in ${RBENV_RUBIES} ; do \
-        rbenv shell \$v && \
-        gem install rake-compiler -v1.2.9 && \
-        cd ${RBENV_ROOT}/versions/\$v/lib/ruby/gems/*/gems/rake-compiler-1.2.9 && \
-        for patch in /home/rubyuser/patches/rake-compiler-1.2.9/*.patch ; do \
-          patch -p1 < \$patch ; \
-        done \
-      done \
-    "
+  for v in ${RBENV_RUBIES} ; do \
+    rbenv shell \$v && \
+    gem install rake-compiler -v1.2.9 && \
+    cd ${RBENV_ROOT}/versions/\$v/lib/ruby/gems/*/gems/rake-compiler-1.2.9 && \
+    for patch in /home/rubyuser/patches/rake-compiler-1.2.9/*.patch ; do \
+      patch -p1 < \$patch ; \
+    done \
+  done \
+"
 
 # Install rake-compiler's cross rubies in global dir instead of /root
 RUN sudo mkdir -p /usr/local/rake-compiler && \
@@ -134,16 +134,16 @@ strip = '-s' if platform !~ /darwin/
 
 xrubies_build_plan.each do |xrubies, bootstrap_ruby_version| %>
 RUN bash -c " \
-      rbenv shell <%= bootstrap_ruby_version %> && \
-      export CPPFLAGS='<%= "-D__USE_MINGW_ANSI_STDIO=1" if platform =~ /x64-mingw-ucrt/ %>' && \
-      export CFLAGS='-O1 -fno-omit-frame-pointer -fno-fast-math -fstack-protector-strong <%= strip %>' && \
-      export LDFLAGS='-pipe <%= strip %>' && \
-      <%= "export LIBS='-l:libssp.a' &&" if platform =~ /mingw/ %> \
-      <%= "export CC=#{target}-clang &&" if platform =~ /darwin/ %> \
-      export MAKE='make V=1' && \
-      rake-compiler cross-ruby VERSION=<%= xrubies %> HOST=<%= target %> && \
-      rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources \
-    "
+  rbenv shell <%= bootstrap_ruby_version %> && \
+  export CPPFLAGS='<%= "-D__USE_MINGW_ANSI_STDIO=1" if platform =~ /x64-mingw-ucrt/ %>' && \
+  export CFLAGS='-O1 -fno-omit-frame-pointer -fno-fast-math -fstack-protector-strong <%= strip %>' && \
+  export LDFLAGS='-pipe <%= strip %>' && \
+  <%= "export LIBS='-l:libssp.a' &&" if platform =~ /mingw/ %> \
+  <%= "export CC=#{target}-clang &&" if platform =~ /darwin/ %> \
+  export MAKE='make V=1' && \
+  rake-compiler cross-ruby VERSION=<%= xrubies %> HOST=<%= target %> && \
+  rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources \
+"
 <% end %>
 # "
 


### PR DESCRIPTION
- [x] add Ruby 3.4.1 as a "host" rbenv ruby
- [x] make it the default
- [x] use it to cross-compile recent Ruby versions

Closes #145 