### PR TITLE
Add new platform aarch64-mingw-ucrt aka Windows on ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           - platform: aarch64-linux-gnu
             alias:    aarch64-linux
           - platform: aarch64-linux-musl
+          - platform: aarch64-mingw-ucrt
           - platform: arm-linux-gnu
             alias:    arm-linux
           - platform: arm-linux-musl

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -15,6 +15,7 @@ jobs:
         platform:
           - aarch64-linux-gnu
           - aarch64-linux-musl
+          - aarch64-mingw-ucrt
           - arm-linux-gnu
           - arm-linux-musl
           - arm64-darwin

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -22,6 +22,7 @@ jobs:
         platform:
           - aarch64-linux-gnu
           - aarch64-linux-musl
+          - aarch64-mingw-ucrt
           - arm-linux-gnu
           - arm-linux-musl
           - arm64-darwin

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -211,6 +211,16 @@ RUN printf "1\n" | update-alternatives --config <%= target %>-gcc && \
     printf "1\n" | update-alternatives --config <%= target %>-g++
 <% end %>
 
+<% if platform =~ /aarch64-mingw/ %>
+# Fool libtool to allow building a shared library although linking to libclang_rt.builtins-aarch64.a
+#
+# Linker option "-llibclang_rt.builtins-aarch64.a" is required on Windows on ARM when compiling C++ and when clang is called with -nostdlib (due to be invoked by libtool).
+# Unfortunately libtool then forces a static build.
+# This is a ugly hack to make libtool beleave that the library is a DLL instead of an archive and to allow building a DLL instand.
+#
+RUN sudo cp /llvm-mingw-20250114-ucrt-ubuntu-20.04-<%= RUBY_PLATFORM[/^\w+/] %>/aarch64-w64-mingw32/bin/libc++.dll /llvm-mingw-20250114-ucrt-ubuntu-20.04-<%= RUBY_PLATFORM[/^\w+/] %>/aarch64-w64-mingw32/lib/libclang_rt.builtins-aarch64.0
+<% end %>
+
 <% if platform =~ /darwin/ %>
 # Install wrapper around strip to re-sign binaries (ad-hoc signature)
 COPY build/strip_wrapper_codesign /root/

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -24,6 +24,13 @@ COPY --from=larskanis/mingw64-ucrt:20.04 \
     /debs/
 RUN dpkg -i /debs/*.deb
 
+<% elsif platform =~ /aarch64-mingw-ucrt/ %>
+RUN wget https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-ubuntu-20.04-<%= RUBY_PLATFORM[/^\w+/] %>.tar.xz && \
+    tar xf llvm-mingw*.tar.xz && \
+    export MINGW_PATH=`ls -d llvm-mingw-*/` && \
+    echo "export PATH=`pwd`/$MINGW_PATH/bin:\$PATH" >> /etc/rubybashrc && \
+    rm -r $MINGW_PATH/bin/i686-w64* $MINGW_PATH/bin/armv7-w64* $MINGW_PATH/bin/x86_64-w64* $MINGW_PATH/i686-w64* $MINGW_PATH/armv7-w64* $MINGW_PATH/x86_64-w64*
+
 <% elsif platform =~ /linux-musl/ %>
 COPY build/mk_musl_cross.sh /tmp
 RUN /tmp/mk_musl_cross.sh <%= target %>
@@ -117,6 +124,10 @@ xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
     # Rubyinstaller-3.1+ is platform x64-mingw-ucrt
     ["3.4.1:3.3.7:3.2.6:3.1.6", "3.4.1"],
   ]
+elsif platform =~ /aarch64-mingw-ucrt/
+  [
+    ["3.4.1", "3.1.6"],
+  ]
 elsif platform =~ /x64-mingw32/
   [
     # Rubyinstaller prior to 3.1 is platform x64-mingw32
@@ -131,7 +142,7 @@ else
   ]
 end
 
-strip = '-s' if platform !~ /darwin/
+strip = '-s' if platform !~ /darwin|aarch64-mingw/
 
 xrubies_build_plan.each do |xrubies, bootstrap_ruby_version| %>
 RUN bash -c " \
@@ -187,7 +198,7 @@ RUN find /usr/local/rake-compiler/ruby/*/*/lib/ruby -name rbconfig.rb | while re
 ##
 USER root
 
-<% if platform =~ /mingw/ %>
+<% if platform =~ /(x64|x86)-mingw/ %>
 # Install wrappers for strip commands as a workaround for "Protocol error" in boot2docker.
 COPY build/strip_wrapper_vbox /root/
 RUN mv /usr/bin/<%= target %>-strip /usr/bin/<%= target %>-strip.bin && \

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -27,9 +27,9 @@ RUN dpkg -i /debs/*.deb
 <% elsif platform =~ /aarch64-mingw-ucrt/ %>
 RUN wget https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-ubuntu-20.04-<%= RUBY_PLATFORM[/^\w+/] %>.tar.xz && \
     tar xf llvm-mingw*.tar.xz && \
-    export MINGW_PATH=`ls -d llvm-mingw-*/` && \
-    echo "export PATH=`pwd`/$MINGW_PATH/bin:\$PATH" >> /etc/rubybashrc && \
-    rm -r $MINGW_PATH/bin/i686-w64* $MINGW_PATH/bin/armv7-w64* $MINGW_PATH/bin/x86_64-w64* $MINGW_PATH/i686-w64* $MINGW_PATH/armv7-w64* $MINGW_PATH/x86_64-w64*
+    mv `ls -d llvm-mingw-*/` /llvm-mingw && \
+    echo "export PATH=/llvm-mingw/bin:\$PATH" >> /etc/rubybashrc && \
+    rm -r /llvm-mingw/bin/i686-w64* /llvm-mingw/bin/armv7-w64* /llvm-mingw/bin/x86_64-w64* /llvm-mingw/i686-w64* /llvm-mingw/armv7-w64* /llvm-mingw/x86_64-w64*
 
 <% elsif platform =~ /linux-musl/ %>
 COPY build/mk_musl_cross.sh /tmp
@@ -218,7 +218,7 @@ RUN printf "1\n" | update-alternatives --config <%= target %>-gcc && \
 # Unfortunately libtool then forces a static build.
 # This is a ugly hack to make libtool beleave that the library is a DLL instead of an archive and to allow building a DLL instand.
 #
-RUN sudo cp /llvm-mingw-20250114-ucrt-ubuntu-20.04-<%= RUBY_PLATFORM[/^\w+/] %>/aarch64-w64-mingw32/bin/libc++.dll /llvm-mingw-20250114-ucrt-ubuntu-20.04-<%= RUBY_PLATFORM[/^\w+/] %>/aarch64-w64-mingw32/lib/libclang_rt.builtins-aarch64.0
+RUN sudo cp /llvm-mingw/aarch64-w64-mingw32/bin/libc++.dll /llvm-mingw/aarch64-w64-mingw32/lib/libclang_rt.builtins-aarch64.0
 <% end %>
 
 <% if platform =~ /darwin/ %>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following platforms are supported for cross-compilation by rake-compiler-doc
 
 - `aarch64-linux` and `aarch64-linux-gnu`
 - `aarch64-linux-musl`
+- `aarch64-mingw-ucrt`
 - `arm-linux` and `arm-linux-gnu`
 - `arm-linux-musl`
 - `arm64-darwin`
@@ -193,6 +194,7 @@ This can be done like this:
 PLATFORMS = %w[
   aarch64-linux-gnu
   aarch64-linux-musl
+  aarch64-mingw-ucrt
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ platforms = [
   # tuple is [platform, target]
   ["aarch64-linux-gnu", "aarch64-linux-gnu"],
   ["aarch64-linux-musl", "aarch64-linux-musl"],
+  ["aarch64-mingw-ucrt", "aarch64-w64-mingw32"],
   ["arm-linux-gnu", "arm-linux-gnueabihf"],
   ["arm-linux-musl", "arm-linux-musleabihf"],
   ["arm64-darwin", "aarch64-apple-darwin"],

--- a/build/patches/rake-compiler-1.2.9/0004-Enable-build-of-static-libruby.patch
+++ b/build/patches/rake-compiler-1.2.9/0004-Enable-build-of-static-libruby.patch
@@ -2,7 +2,7 @@ diff --git a/tasks/bin/cross-ruby.rake b/tasks/bin/cross-ruby.rake
 index 8317a2a3..8ed21718 100644
 --- a/tasks/bin/cross-ruby.rake
 +++ b/tasks/bin/cross-ruby.rake
-@@ -116,11 +116,30 @@
+@@ -116,11 +116,31 @@
          "--host=#{mingw_host}",
          "--target=#{mingw_target}",
          "--build=#{RUBY_BUILD}",
@@ -12,6 +12,7 @@ index 8317a2a3..8ed21718 100644
 +        'ac_cv_lib_z_uncompress=no',
 +        'ac_cv_lib_crypt_crypt=no',
 +        'ac_cv_func_crypt_r=no',
++        'extra_warnflags=-Wno-shorten-64-to-32 -Wno-dll-attribute-on-redeclaration',
          '--disable-install-doc',
          '--with-ext=',
        ]

--- a/test/rcd_test/Rakefile
+++ b/test/rcd_test/Rakefile
@@ -22,6 +22,7 @@ else
       aarch64-linux
       aarch64-linux-gnu
       aarch64-linux-musl
+      aarch64-mingw-ucrt
       arm-linux
       arm-linux-gnu
       arm-linux-musl

--- a/test/rcd_test/ext/mri/extconf.rb
+++ b/test/rcd_test/ext/mri/extconf.rb
@@ -18,6 +18,8 @@ else
   puts "cc --version: #{ %x[#{CONFIG['CC']} --version].lines.first}"
   puts "-"*70
 
+  $CFLAGS << " -Wall -Werror"
+
   have_func('rb_thread_call_without_gvl', 'ruby/thread.h') ||
       raise("rb_thread_call_without_gvl() not found")
 


### PR DESCRIPTION
It fits to the latest RubyInstaller release:
  https://rubyinstaller.org/2025/01/19/rubyinstaller-3.4.1-2-released.html

Fixes #148