### PR TITLE
Replace deprecated `bundle package --all` call

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ PLATFORMS = %w[
 task 'gem:native' do
   require 'rake_compiler_dock'
   sh "bundle config set cache_all true"   # Avoid repeated downloads of gems by using gem files from the host.
+  sh "bundle package"
   PLATFORMS.each do |plat|
     RakeCompilerDock.sh "bundle --local && rake native:#{plat} gem", platform: plat
   end
@@ -230,6 +231,7 @@ Please note, that parallel builds only work reliable, if the specific platform g
       require 'rake_compiler_dock'
       require 'io/console'
       sh "bundle config set cache_all true"
+      sh "bundle package"
       sh "cp ~/.gem/gem-*.pem build/gem/ || true"
       ENV["GEM_PRIVATE_KEY_PASSPHRASE"] = STDIN.getpass("Enter passphrase of gem signature key: ")
     end

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ PLATFORMS = %w[
 ]
 task 'gem:native' do
   require 'rake_compiler_dock'
-  sh "bundle package --all"   # Avoid repeated downloads of gems by using gem files from the host.
+  sh "bundle config set cache_all true"   # Avoid repeated downloads of gems by using gem files from the host.
   PLATFORMS.each do |plat|
     RakeCompilerDock.sh "bundle --local && rake native:#{plat} gem", platform: plat
   end

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Please note, that parallel builds only work reliable, if the specific platform g
     task 'prepare' do
       require 'rake_compiler_dock'
       require 'io/console'
-      sh "bundle package --all"
+      sh "bundle config set cache_all true"
       sh "cp ~/.gem/gem-*.pem build/gem/ || true"
       ENV["GEM_PRIVATE_KEY_PASSPHRASE"] = STDIN.getpass("Enter passphrase of gem signature key: ")
     end


### PR DESCRIPTION
Hey, thank you for this awesome gem! 

I just started using `rake-compiler-dock` and it already massively simplified my life for precompiling one of my gems! ❤️

I noticed that the `bundle package --all` call which is referenced in the README was deprecated:

```
[DEPRECATED] The `--all` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set cache_all true`, and stop using this flag
```

This pull request updates the `bundle package --all` calls to `bundle config set cache_all true` and `bundle package` to avoid the deprecation warning when compiling a gem.