### PR TITLE
Move install of mig to osxcross install

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -28,20 +28,19 @@ RUN dpkg -i /debs/*.deb
 
 <% elsif platform =~ /aarch64-mingw-ucrt/ %>
 
-RUN echo $TARGETPLATFORM
 RUN <<EOF
-if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
-    DOWNLOAD_PLATFORM="x86_64";
-elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
-    DOWNLOAD_PLATFORM="aarch64";
-else
-    echo "Unsupported platform $TARGETPLATFORM";
-    exit 1;
-fi &&
-wget https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-ubuntu-20.04-$DOWNLOAD_PLATFORM.tar.xz && \
-    tar xf llvm-mingw*.tar.xz && \
-    mv `ls -d llvm-mingw-*/` /llvm-mingw && \
-    echo "export PATH=/llvm-mingw/bin:\$PATH" >> /etc/rubybashrc && \
+    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
+        DOWNLOAD_PLATFORM="x86_64";
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
+        DOWNLOAD_PLATFORM="aarch64";
+    else
+        echo "Unsupported platform $TARGETPLATFORM";
+        exit 1;
+    fi &&
+    wget https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-ubuntu-20.04-$DOWNLOAD_PLATFORM.tar.xz &&
+    tar xf llvm-mingw*.tar.xz &&
+    mv `ls -d llvm-mingw-*/` /llvm-mingw &&
+    echo "export PATH=/llvm-mingw/bin:\$PATH" >> /etc/rubybashrc &&
     rm -r /llvm-mingw/bin/i686-w64* /llvm-mingw/bin/armv7-w64* /llvm-mingw/bin/x86_64-w64* /llvm-mingw/i686-w64* /llvm-mingw/armv7-w64* /llvm-mingw/x86_64-w64*
 EOF
 
@@ -65,6 +64,20 @@ if platform =~ /x64-mingw32/       %> gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 
 <% if platform =~ /darwin/ %>
 COPY build/mk_osxcross.sh /tmp
 RUN /tmp/mk_osxcross.sh
+
+# Install mig which is a Macos specific RPC code generator, which is part of xcode
+RUN apt-get -y update && \
+    apt-get install -y bison flex && \
+    rm -rf /var/lib/apt/lists/*
+RUN git clone --branch=cross_platform https://github.com/markmentovai/bootstrap_cmds && \
+    cd bootstrap_cmds && \
+    autoreconf --install && \
+    sh configure && \
+    make && \
+    sed -E -i 's/^cppflags=(.*)/cppflags=(\1 "-D<%= platform =~ /arm64/ ? "__arm64__" : "__x86_64__" %>" "-I\/opt\/osxcross\/target\/SDK\/MacOSX11.1.sdk\/usr\/include")/' migcom.tproj/mig.sh && \
+    sudo make install && \
+    cd .. && \
+    rm -rf bootstrap_cmds
 <% end %>
 
 
@@ -232,18 +245,6 @@ RUN sudo cp /llvm-mingw/aarch64-w64-mingw32/bin/libc++.dll /llvm-mingw/aarch64-w
 COPY build/strip_wrapper_codesign /root/
 RUN mv /opt/osxcross/target/bin/<%= target %>-strip /opt/osxcross/target/bin/<%= target %>-strip.bin && \
     ln /root/strip_wrapper_codesign /opt/osxcross/target/bin/<%= target %>-strip
-
-# Install mig which is a Macos specific RPC code generator, which is part of xcode
-RUN apt-get -y update && \
-    apt-get install -y bison flex && \
-    rm -rf /var/lib/apt/lists/*
-RUN git clone --branch=cross_platform https://github.com/markmentovai/bootstrap_cmds && \
-    cd bootstrap_cmds && \
-    autoreconf --install && \
-    sh configure && \
-    make && \
-    sed -E -i 's/^cppflags=(.*)/cppflags=(\1 "-D<%= platform =~ /arm64/ ? "__arm64__" : "__x86_64__" %>" "-I\/opt\/osxcross\/target\/SDK\/MacOSX11.1.sdk\/usr\/include")/' migcom.tproj/mig.sh && \
-    sudo make install
 <% end %>
 
 <% if platform =~ /arm64-darwin/ %>


### PR DESCRIPTION
.. since it is not cross platform dependent, so we can save some space when common image layers are used.

Also adjust indention.