### PR TITLE
Bump VERSION to 1.10.0

### DIFF
--- a/lib/rake_compiler_dock/version.rb
+++ b/lib/rake_compiler_dock/version.rb
@@ -1,4 +1,4 @@
 module RakeCompilerDock
-  VERSION = "1.9.1"
-  IMAGE_VERSION = "1.9.1"
+  VERSION = "1.10.0"
+  IMAGE_VERSION = "1.10.0"
 end


### PR DESCRIPTION
I'd like to make a new release 1.10.0 with multi-platform images for x86_64 and arm64 (will fix #78).

Would be nice to include #156 which is green now.