### PR TITLE
Add RCD_IMAGE_VERSION env var to easily set image version

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -107,21 +107,10 @@ jobs:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - name: Generate docker image names
-        id: rcd_config
-        run: |
-          bundle exec ruby -e ' \
-            require "rake_compiler_dock"; \
-            print "snapshot_name_opt=-t "; \
-            puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}}), :version => %q(snapshot)); \
-            if %q(${{matrix.platform}}).end_with?("-gnu"); \
-              print "generic_linux_snapshot_name_opt=-t "; \
-              puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}}), :version => %q(snapshot)).chomp("-gnu"); \
-            end \
-          ' | tee -a $GITHUB_OUTPUT
       - name: Use cache and push docker image
         env:
-          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache-X64 --cache-from=type=local,src=tmp/build-cache-ARM64 --cache-to=type=local,dest=tmp/build-cache-new ${{steps.rcd_config.outputs.snapshot_name_opt}} ${{steps.rcd_config.outputs.generic_linux_snapshot_name_opt}}
+          RCD_IMAGE_VERSION: snapshot
+          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache-X64 --cache-from=type=local,src=tmp/build-cache-ARM64 --cache-to=type=local,dest=tmp/build-cache-new
         run: |
           docker buildx create --driver docker-container --use
           bundle exec rake release:${{matrix.platform}}

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -110,51 +110,14 @@ jobs:
         with:
           ruby-version: "3.3"
           bundler-cache: true
-      - name: Generate docker image names
-        id: rcd_config
-        run: |
-          bundle exec ruby -e ' \
-            require "rake_compiler_dock"; \
-            print "image_name_opt=-t "; \
-            puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}})); \
-            print "snapshot_name_opt=-t "; \
-            puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}}), :version => %q(snapshot)); \
-            if %q(${{matrix.platform}}).end_with?("-gnu"); \
-              print "generic_linux_snapshot_name_opt=-t "; \
-              puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}}), :version => %q(snapshot)).chomp("-gnu"); \
-            end \
-          ' | tee -a $GITHUB_OUTPUT
-
-
-          bundle exec ruby -e ' \
-            require "rake_compiler_dock"; \
-            print "image_name="; \
-            puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}})); \
-            if %q(${{matrix.platform}}).end_with?("-gnu"); \
-              print "generic_linux_image_name="; \
-              puts RakeCompilerDock::Starter.container_image_name(:platform => %q(${{matrix.platform}})).chomp("-gnu"); \
-            end \
-          ' | tee -a $GITHUB_OUTPUT
-      - name: Build docker image
-        env:
-          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache --cache-to=type=local,dest=tmp/build-cache-new
-        run: |
-          docker buildx create --driver docker-container --use
-          bundle exec rake build:x86:${{matrix.platform}}
-          # move build cache and remove outdated layers
-          rm -rf tmp/build-cache
-          mv tmp/build-cache-new tmp/build-cache
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - name: Push the docker image
+      - name: Use cache and push docker image
+        env:
+          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache-X64 --cache-from=type=local,src=tmp/build-cache-ARM64 --cache-to=type=local,dest=tmp/build-cache-new
         run: |
-          docker images
-          docker push ${{steps.rcd_config.outputs.image_name}}
-      - name: Push a generic linux image
-        if: ${{ steps.rcd_config.outputs.generic_linux_image_name }}
-        run: |
-          docker tag ${{steps.rcd_config.outputs.image_name}} ${{steps.rcd_config.outputs.generic_linux_image_name}}
-          docker push ${{steps.rcd_config.outputs.generic_linux_image_name}}
+          docker buildx create --driver docker-container --use
+          bundle exec rake release:${{matrix.platform}}

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ OCI images snapshotted from `main` are published weekly to Github Container Regi
 - `ghcr.io/rake-compiler/rake-compiler-dock-image:snapshot-mri-x86_64-linux-gnu`
 
 These images are intended for integration testing. They may not work properly and should not be considered production ready.
+Snapshot images can be used by setting `RCD_IMAGE_VERSION` environment variable.
 
 
 ## Environment Variables
@@ -330,6 +331,9 @@ The following variables are recognized by rake-compiler-dock:
     It is ignored when `rubyvm` is set to `:jruby`.
 * `RCD_IMAGE` - The docker image that is downloaded and started.
     Defaults to "ghcr.io/rake-compiler/rake-compiler-dock-image:IMAGE_VERSION-PLATFORM" with an image version that is determined by the gem version.
+* `RCD_IMAGE_VERSION` - The docker image version that is downloaded and started.
+    Defaults to the version of the rake-compiler-dock gem in use.
+    Can be set to `snapshot` in order to use the latest images from main branch.
 
 The following variables are passed through to the docker container without modification:
 

--- a/lib/rake_compiler_dock/starter.rb
+++ b/lib/rake_compiler_dock/starter.rb
@@ -167,7 +167,7 @@ module RakeCompilerDock
 
           "%s/rake-compiler-dock-image:%s-%s%s" % [
             container_registry,
-            options.fetch(:version) { IMAGE_VERSION },
+            options.fetch(:version) { image_version },
             container_rubyvm(options),
             container_jrubyvm?(options) ? "" : "-#{options.fetch(:platform)}",
           ]
@@ -176,6 +176,10 @@ module RakeCompilerDock
 
       def container_registry
         ENV['CONTAINER_REGISTRY'] || "ghcr.io/rake-compiler"
+      end
+
+      def image_version
+        ENV['RCD_IMAGE_VERSION'] || IMAGE_VERSION
       end
 
       def container_rubyvm(options={})

--- a/test/test_starter.rb
+++ b/test/test_starter.rb
@@ -38,6 +38,12 @@ class TestStarter < Test::Unit::TestCase
     with_env({"RAKE_COMPILER_DOCK_IMAGE" => "env-var-value"}) do
       assert_equal("env-var-value", Starter.container_image_name)
     end
+    with_env({"CONTAINER_REGISTRY" => "env-var-value"}) do
+      assert_match(/env-var-value\//, Starter.container_image_name(platform: "x64-mingw-ucrt"))
+    end
+    with_env({"RCD_IMAGE_VERSION" => "env-var-value"}) do
+      assert_match(/:env-var-value-/, Starter.container_image_name(platform: "x64-mingw-ucrt"))
+    end
 
     # with image option
     assert_equal("option-value", Starter.container_image_name({:image => "option-value"}))


### PR DESCRIPTION
.. and to avoid pushing numbered version `1.9.1` AND `snapshot` version in the publish workflow.

Also adjust the release workflow similarly.

This also allows to build platform gems with `snapshot` images by something like:
```ruby
RCD_IMAGE_VERSION=snapshot rake gem:native
```

As documented in the README.

Fixes #162