### PR TITLE
Disable rpath in cross compiled C extensions

### DIFF
--- a/build/patches/rake-compiler-1.2.9/0004-Enable-build-of-static-libruby.patch
+++ b/build/patches/rake-compiler-1.2.9/0004-Enable-build-of-static-libruby.patch
@@ -2,13 +2,14 @@ diff --git a/tasks/bin/cross-ruby.rake b/tasks/bin/cross-ruby.rake
 index 8317a2a3..8ed21718 100644
 --- a/tasks/bin/cross-ruby.rake
 +++ b/tasks/bin/cross-ruby.rake
-@@ -116,11 +116,31 @@
+@@ -116,11 +116,32 @@
          "--host=#{mingw_host}",
          "--target=#{mingw_target}",
          "--build=#{RUBY_BUILD}",
 -        '--enable-shared',
 +        '--enable-install-static-library',
 +        '--disable-jit-support',
++        '--disable-rpath',
 +        'ac_cv_lib_z_uncompress=no',
 +        'ac_cv_lib_crypt_crypt=no',
 +        'ac_cv_func_crypt_r=no',

--- a/test/rcd_test/test/test_basic.rb
+++ b/test/rcd_test/test/test_basic.rb
@@ -35,4 +35,15 @@ class TestBasic < Minitest::Test
     is_linux = RUBY_PLATFORM.include?("linux")
     assert_equal(is_linux, RcdTest.largefile_op_removed_from_musl)
   end
+
+  def test_disabled_rpath
+    skip("jruby uses jar files without rpath") if RUBY_ENGINE == "jruby"
+
+    cext_fname = $LOADED_FEATURES.grep(/rcd_test_ext/).first
+    refute_nil(cext_fname, "the C-ext should be loaded")
+    cext_text = File.binread(cext_fname)
+    assert_match(/Init_rcd_test_ext/, cext_text, "C-ext shoud contain the init function")
+    refute_match(/usr\/local/, cext_text, "there should be no rpath to /usr/local/rake-compiler/ruby/x86_64-unknown-linux-musl/ruby-3.4.5/lib or so")
+    refute_match(/home\//, cext_text, "there should be no path to /home/ or so")
+  end
 end


### PR DESCRIPTION
This instructs cross rubies to omit the rpath linker option to the absolute path in the build environment, which is like

```
-Wl,-rpath,/home/kanis/.rvm/rubies/ruby-3.4.5/lib
```

This path is not present on the target system and could lead to security issues.

Related to https://github.com/sparklemotion/nokogiri/issues/3133 and https://github.com/ged/ruby-pg/pull/668