### PR TITLE
Bump Ruby versions in MRI containers

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -108,7 +108,7 @@ ENV BASH_ENV=/etc/rubybashrc
 ##
 USER rubyuser
 
-ENV RBENV_RUBIES="3.1.7 3.4.5"
+ENV RBENV_RUBIES="3.1.7 3.4.7"
 
 # Install the bootstrap rubies
 RUN bash -c " \
@@ -148,11 +148,11 @@ RUN sudo mkdir -p /usr/local/rake-compiler && \
 xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1+ is platform x64-mingw-ucrt
-    ["3.4.5:3.3.9:3.2.9:3.1.7", "3.4.5"],
+    ["3.4.7:3.3.10:3.2.9:3.1.7", "3.4.7"],
   ]
 elsif platform =~ /aarch64-mingw-ucrt/
   [
-    ["3.4.5", "3.1.7"],
+    ["3.4.7", "3.1.7"],
   ]
 elsif platform =~ /x64-mingw32/
   [
@@ -162,7 +162,7 @@ elsif platform =~ /x64-mingw32/
 else
   [
     ["2.7.8", "3.1.7"],
-    ["3.4.5:3.3.9:3.2.9:3.1.7:3.0.7", "3.4.5"],
+    ["3.4.7:3.3.10:3.2.9:3.1.7:3.0.7", "3.4.7"],
   ]
 end
 
@@ -264,8 +264,8 @@ RUN echo 'source /etc/profile.d/rcd-env.sh' >> /etc/rubybashrc
 # Install sudoers configuration
 COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
-RUN bash -c "rbenv global 3.4.5"
+RUN bash -c "rbenv global 3.4.7"
 
-ENV RUBY_CC_VERSION=3.4.5:3.3.9:3.2.9:3.1.7:3.0.7:2.7.8
+ENV RUBY_CC_VERSION=3.4.7:3.3.10:3.2.9:3.1.7:3.0.7:2.7.8
 
 CMD bash

--- a/lib/rake_compiler_dock.rb
+++ b/lib/rake_compiler_dock.rb
@@ -82,8 +82,8 @@ module RakeCompilerDock
   #
   #   RakeCompilerDock.cross_rubies
   #   # => {
-  #   #      "3.4" => "3.4.5",
-  #   #      "3.3" => "3.3.9",
+  #   #      "3.4" => "3.4.7",
+  #   #      "3.3" => "3.3.10",
   #   #      "3.2" => "3.2.9",
   #   #      "3.1" => "3.1.7",
   #   #      "3.0" => "3.0.7",
@@ -92,8 +92,8 @@ module RakeCompilerDock
   #
   def cross_rubies
     {
-      "3.4" => "3.4.5",
-      "3.3" => "3.3.9",
+      "3.4" => "3.4.7",
+      "3.3" => "3.3.10",
       "3.2" => "3.2.9",
       "3.1" => "3.1.7",
       "3.0" => "3.0.7",
@@ -112,13 +112,13 @@ module RakeCompilerDock
   #
   # For example:
   #   RakeCompilerDock.ruby_cc_version("2.7", "3.4")
-  #   # => "3.4.5:2.7.8"
+  #   # => "3.4.7:2.7.8"
   #
   #   RakeCompilerDock.ruby_cc_version("~> 3.2")
-  #   # => "3.4.5:3.3.9:3.2.9"
+  #   # => "3.4.7:3.3.10:3.2.9"
   #
   #   RakeCompilerDock.ruby_cc_version(Gem::Requirement.new("~> 3.2"))
-  #   # => "3.4.5:3.3.9:3.2.9"
+  #   # => "3.4.7:3.3.10:3.2.9"
   #
   def ruby_cc_version(*requirements)
     cross = cross_rubies


### PR DESCRIPTION
I followed #156 to bump the Ruby versions in the MRI containers:

Native runtime rubies:
- 3.4.5 → 3.4.7
- 3.3.9 → 3.3.10

Rbenv (host) rubies:
- 3.4.5 → 3.4.7

Let me know if we need any other changes, or if this is not relevant and we want to keep the old Ruby versions, thank you!