### PR TITLE
Do docker push in one combined rake task to decrease size of the images

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,15 +1,21 @@
-name: Publish docker images to GHCR
-concurrency:
-  group: "${{github.workflow}}-${{github.ref}}"
-  cancel-in-progress: true
+
+name: Weekly publish docker images to GHCR
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * 3" # At 03:00 on Wednesday # https://crontab.guru/#0_3_*_*_3
 
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+
+
+
 jobs:
   build:
-    name: build native
+    name: "build ${{ matrix.platform }} ${{ matrix.os }}"
     strategy:
       fail-fast: false
       matrix:
@@ -17,24 +23,41 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
         platform:
+
           - aarch64-linux-gnu
+
           - aarch64-linux-musl
+
           - aarch64-mingw-ucrt
+
           - arm-linux-gnu
+
           - arm-linux-musl
+
           - arm64-darwin
+
           - jruby
+
           - x64-mingw-ucrt
+
           - x64-mingw32
+
           - x86-linux-gnu
+
           - x86-linux-musl
+
           - x86-mingw32
+
           - x86_64-darwin
+
           - x86_64-linux-gnu
+
           - x86_64-linux-musl
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
@@ -47,8 +70,9 @@ jobs:
           key: ${{ runner.os }}-on-${{ runner.arch }}-${{ matrix.platform }}-buildx-${{ github.sha }}
           restore-keys: ${{ runner.os }}-on-${{ runner.arch }}-${{ matrix.platform }}-buildx
           enableCrossOsArchive: true
-      - name: Change docker to a cache-able driver
+      - name: Build the image for platform ${{ matrix.platform }} on ${{ runner.arch }}
         run: |
+          # Change docker to a cache-able driver
           docker buildx create --driver docker-container --use
           bundle exec rake build:${{ matrix.platform }} RCD_DOCKER_BUILD="docker buildx build --cache-from=type=local,src=tmp/build-cache-${{ runner.arch }} --cache-to=type=local,dest=tmp/build-cache-new"
       - name: Show docker images
@@ -63,41 +87,280 @@ jobs:
     needs: build
     strategy:
       fail-fast: false
-      matrix:
-        platform:
-          - aarch64-linux-gnu
-          - aarch64-linux-musl
-          - aarch64-mingw-ucrt
-          - arm-linux-gnu
-          - arm-linux-musl
-          - arm64-darwin
-          - jruby
-          - x64-mingw-ucrt
-          - x64-mingw32
-          - x86-linux-gnu
-          - x86-linux-musl
-          - x86-mingw32
-          - x86_64-darwin
-          - x86_64-linux-gnu
-          - x86_64-linux-musl
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use X64 cache from primary pipeline
+
+      - name: Use X64 cache from primary pipeline of aarch64-linux-gnu
         uses: actions/cache/restore@v4
         with:
           path: tmp/build-cache-X64
-          key: ${{ runner.os }}-on-X64-${{ matrix.platform }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-on-X64-${{ matrix.platform }}-buildx
+          key: ${{ runner.os }}-on-X64-aarch64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-aarch64-linux-gnu-buildx
           enableCrossOsArchive: true
-      - name: Use ARM64 cache from primary pipeline
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-aarch64-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of aarch64-linux-gnu
         uses: actions/cache/restore@v4
         with:
           path: tmp/build-cache-ARM64
-          key: ${{ runner.os }}-on-ARM64-${{ matrix.platform }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-on-ARM64-${{ matrix.platform }}-buildx
+          key: ${{ runner.os }}-on-ARM64-aarch64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-aarch64-linux-gnu-buildx
           enableCrossOsArchive: true
           fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-aarch64-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of aarch64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-aarch64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-aarch64-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-aarch64-linux-musl
+      - name: Use ARM64 cache from primary pipeline of aarch64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-aarch64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-aarch64-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-aarch64-linux-musl
+
+      - name: Use X64 cache from primary pipeline of aarch64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-aarch64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-aarch64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-aarch64-mingw-ucrt
+      - name: Use ARM64 cache from primary pipeline of aarch64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-aarch64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-aarch64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-aarch64-mingw-ucrt
+
+      - name: Use X64 cache from primary pipeline of arm-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-arm-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-arm-linux-gnu-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-arm-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of arm-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-arm-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-arm-linux-gnu-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-arm-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of arm-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-arm-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-arm-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-arm-linux-musl
+      - name: Use ARM64 cache from primary pipeline of arm-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-arm-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-arm-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-arm-linux-musl
+
+      - name: Use X64 cache from primary pipeline of arm64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-arm64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-arm64-darwin-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-arm64-darwin
+      - name: Use ARM64 cache from primary pipeline of arm64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-arm64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-arm64-darwin-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-arm64-darwin
+
+      - name: Use X64 cache from primary pipeline of jruby
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-jruby-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-jruby-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-jruby
+      - name: Use ARM64 cache from primary pipeline of jruby
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-jruby-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-jruby-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-jruby
+
+      - name: Use X64 cache from primary pipeline of x64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x64-mingw-ucrt
+      - name: Use ARM64 cache from primary pipeline of x64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x64-mingw-ucrt
+
+      - name: Use X64 cache from primary pipeline of x64-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x64-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x64-mingw32-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x64-mingw32
+      - name: Use ARM64 cache from primary pipeline of x64-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x64-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x64-mingw32-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x64-mingw32
+
+      - name: Use X64 cache from primary pipeline of x86-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86-linux-gnu-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of x86-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86-linux-gnu-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of x86-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86-linux-musl
+      - name: Use ARM64 cache from primary pipeline of x86-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86-linux-musl
+
+      - name: Use X64 cache from primary pipeline of x86-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86-mingw32-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86-mingw32
+      - name: Use ARM64 cache from primary pipeline of x86-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86-mingw32-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86-mingw32
+
+      - name: Use X64 cache from primary pipeline of x86_64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86_64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86_64-darwin-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86_64-darwin
+      - name: Use ARM64 cache from primary pipeline of x86_64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86_64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86_64-darwin-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86_64-darwin
+
+      - name: Use X64 cache from primary pipeline of x86_64-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86_64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86_64-linux-gnu-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86_64-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of x86_64-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86_64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86_64-linux-gnu-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86_64-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of x86_64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86_64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86_64-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86_64-linux-musl
+      - name: Use ARM64 cache from primary pipeline of x86_64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86_64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86_64-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86_64-linux-musl
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
@@ -110,7 +373,7 @@ jobs:
       - name: Use cache and push docker image
         env:
           RCD_IMAGE_VERSION: snapshot
-          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache-X64 --cache-from=type=local,src=tmp/build-cache-ARM64 --cache-to=type=local,dest=tmp/build-cache-new
+          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache-X64-aarch64-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-aarch64-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-aarch64-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-aarch64-linux-musl --cache-from=type=local,src=tmp/build-cache-X64-aarch64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-ARM64-aarch64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-X64-arm-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-arm-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-arm-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-arm-linux-musl --cache-from=type=local,src=tmp/build-cache-X64-arm64-darwin --cache-from=type=local,src=tmp/build-cache-ARM64-arm64-darwin --cache-from=type=local,src=tmp/build-cache-X64-jruby --cache-from=type=local,src=tmp/build-cache-ARM64-jruby --cache-from=type=local,src=tmp/build-cache-X64-x64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-ARM64-x64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-X64-x64-mingw32 --cache-from=type=local,src=tmp/build-cache-ARM64-x64-mingw32 --cache-from=type=local,src=tmp/build-cache-X64-x86-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-x86-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-x86-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-x86-linux-musl --cache-from=type=local,src=tmp/build-cache-X64-x86-mingw32 --cache-from=type=local,src=tmp/build-cache-ARM64-x86-mingw32 --cache-from=type=local,src=tmp/build-cache-X64-x86_64-darwin --cache-from=type=local,src=tmp/build-cache-ARM64-x86_64-darwin --cache-from=type=local,src=tmp/build-cache-X64-x86_64-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-x86_64-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-x86_64-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-x86_64-linux-musl  --cache-to=type=local,dest=tmp/build-cache-new
         run: |
           docker buildx create --driver docker-container --use
-          bundle exec rake release:${{matrix.platform}}
+          bundle exec rake release:images

--- a/.github/workflows/publish-images.yml.erb
+++ b/.github/workflows/publish-images.yml.erb
@@ -1,0 +1,132 @@
+<% if release %>
+name: Release docker images to GHCR
+#
+#  This workflow assumes the maintainer has chosen the appropriate tag in the workflow dispatch UI.
+#
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name to release"
+        required: true
+
+<% else %>
+name: Weekly publish docker images to GHCR
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 3" # At 03:00 on Wednesday # https://crontab.guru/#0_3_*_*_3
+<% end %>
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+
+<%
+platforms = %w[
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  aarch64-mingw-ucrt
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  jruby
+  x64-mingw-ucrt
+  x64-mingw32
+  x86-linux-gnu
+  x86-linux-musl
+  x86-mingw32
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+]
+%>
+
+jobs:
+  build:
+    name: "build ${{ matrix.platform }} ${{ matrix.os }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+        platform:
+<% platforms.each do |pl| %>
+          <%= "- #{pl}" %>
+<% end %>
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+<% if release %>
+        with:
+          ref: ${{ inputs.tag }}
+<% end %>
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Fetch docker buildx layer cache
+        uses: actions/cache@v4
+        with:
+          path: tmp/build-cache-${{ runner.arch }}
+          key: ${{ runner.os }}-on-${{ runner.arch }}-${{ matrix.platform }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-${{ runner.arch }}-${{ matrix.platform }}-buildx
+          enableCrossOsArchive: true
+      - name: Build the image for platform ${{ matrix.platform }} on ${{ runner.arch }}
+        run: |
+          # Change docker to a cache-able driver
+          docker buildx create --driver docker-container --use
+          bundle exec rake build:${{ matrix.platform }} RCD_DOCKER_BUILD="docker buildx build --cache-from=type=local,src=tmp/build-cache-${{ runner.arch }} --cache-to=type=local,dest=tmp/build-cache-new"
+      - name: Show docker images
+        run: docker images
+      - name: Update and prune docker buildx layer cache
+        run: |
+          rm -rf tmp/build-cache-${{ runner.arch }}
+          mv tmp/build-cache-new tmp/build-cache-${{ runner.arch }}
+
+  push:
+    name: push
+    needs: build
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+<% platforms.each do |pl| %>
+      - name: Use X64 cache from primary pipeline of <%= pl %>
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-<%= pl %>-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-<%= pl %>-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-<%= pl %>
+      - name: Use ARM64 cache from primary pipeline of <%= pl %>
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-<%= pl %>-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-<%= pl %>-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-<%= pl %>
+<% end %>
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: Use cache and push docker image
+        env:
+          RCD_IMAGE_VERSION: snapshot
+          RCD_DOCKER_BUILD: docker buildx build <%= platforms.map{|pl| "--cache-from=type=local,src=tmp/build-cache-X64-#{pl} --cache-from=type=local,src=tmp/build-cache-ARM64-#{pl} " }.join %> --cache-to=type=local,dest=tmp/build-cache-new
+        run: |
+          docker buildx create --driver docker-container --use
+          bundle exec rake release:images

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,8 +1,5 @@
-name: Release docker images to GHCR
-concurrency:
-  group: "${{github.workflow}}-${{github.ref}}"
-  cancel-in-progress: true
 
+name: Release docker images to GHCR
 #
 #  This workflow assumes the maintainer has chosen the appropriate tag in the workflow dispatch UI.
 #
@@ -13,9 +10,18 @@ on:
         description: "Tag name to release"
         required: true
 
+
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
+
+
+
+
 jobs:
   build:
-    name: "build ${{ inputs.tag }} ${{ matrix.platform }}"
+    name: "build ${{ matrix.platform }} ${{ matrix.os }}"
     strategy:
       fail-fast: false
       matrix:
@@ -23,24 +29,44 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
         platform:
+
           - aarch64-linux-gnu
+
           - aarch64-linux-musl
+
           - aarch64-mingw-ucrt
+
           - arm-linux-gnu
+
           - arm-linux-musl
+
           - arm64-darwin
+
           - jruby
+
           - x64-mingw-ucrt
+
           - x64-mingw32
+
           - x86-linux-gnu
+
           - x86-linux-musl
+
           - x86-mingw32
+
           - x86_64-darwin
+
           - x86_64-linux-gnu
+
           - x86_64-linux-musl
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
+        with:
+          ref: ${{ inputs.tag }}
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
@@ -53,8 +79,9 @@ jobs:
           key: ${{ runner.os }}-on-${{ runner.arch }}-${{ matrix.platform }}-buildx-${{ github.sha }}
           restore-keys: ${{ runner.os }}-on-${{ runner.arch }}-${{ matrix.platform }}-buildx
           enableCrossOsArchive: true
-      - name: Change docker to a cache-able driver
+      - name: Build the image for platform ${{ matrix.platform }} on ${{ runner.arch }}
         run: |
+          # Change docker to a cache-able driver
           docker buildx create --driver docker-container --use
           bundle exec rake build:${{ matrix.platform }} RCD_DOCKER_BUILD="docker buildx build --cache-from=type=local,src=tmp/build-cache-${{ runner.arch }} --cache-to=type=local,dest=tmp/build-cache-new"
       - name: Show docker images
@@ -65,47 +92,284 @@ jobs:
           mv tmp/build-cache-new tmp/build-cache-${{ runner.arch }}
 
   push:
+    name: push
     needs: build
-    name: "push ${{ inputs.tag }} ${{ matrix.platform }}"
     strategy:
       fail-fast: false
-      matrix:
-        platform:
-          - aarch64-linux-gnu
-          - aarch64-linux-musl
-          - aarch64-mingw-ucrt
-          - arm-linux-gnu
-          - arm-linux-musl
-          - arm64-darwin
-          - jruby
-          - x64-mingw-ucrt
-          - x64-mingw32
-          - x86-linux-gnu
-          - x86-linux-musl
-          - x86-mingw32
-          - x86_64-darwin
-          - x86_64-linux-gnu
-          - x86_64-linux-musl
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
-      - name: Use X64 cache from primary pipeline
+
+      - name: Use X64 cache from primary pipeline of aarch64-linux-gnu
         uses: actions/cache/restore@v4
         with:
           path: tmp/build-cache-X64
-          key: ${{ runner.os }}-on-X64-${{ matrix.platform }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-on-X64-${{ matrix.platform }}-buildx
+          key: ${{ runner.os }}-on-X64-aarch64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-aarch64-linux-gnu-buildx
           enableCrossOsArchive: true
-      - name: Use ARM64 cache from primary pipeline
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-aarch64-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of aarch64-linux-gnu
         uses: actions/cache/restore@v4
         with:
           path: tmp/build-cache-ARM64
-          key: ${{ runner.os }}-on-ARM64-${{ matrix.platform }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-on-ARM64-${{ matrix.platform }}-buildx
+          key: ${{ runner.os }}-on-ARM64-aarch64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-aarch64-linux-gnu-buildx
           enableCrossOsArchive: true
           fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-aarch64-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of aarch64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-aarch64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-aarch64-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-aarch64-linux-musl
+      - name: Use ARM64 cache from primary pipeline of aarch64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-aarch64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-aarch64-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-aarch64-linux-musl
+
+      - name: Use X64 cache from primary pipeline of aarch64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-aarch64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-aarch64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-aarch64-mingw-ucrt
+      - name: Use ARM64 cache from primary pipeline of aarch64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-aarch64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-aarch64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-aarch64-mingw-ucrt
+
+      - name: Use X64 cache from primary pipeline of arm-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-arm-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-arm-linux-gnu-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-arm-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of arm-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-arm-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-arm-linux-gnu-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-arm-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of arm-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-arm-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-arm-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-arm-linux-musl
+      - name: Use ARM64 cache from primary pipeline of arm-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-arm-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-arm-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-arm-linux-musl
+
+      - name: Use X64 cache from primary pipeline of arm64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-arm64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-arm64-darwin-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-arm64-darwin
+      - name: Use ARM64 cache from primary pipeline of arm64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-arm64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-arm64-darwin-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-arm64-darwin
+
+      - name: Use X64 cache from primary pipeline of jruby
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-jruby-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-jruby-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-jruby
+      - name: Use ARM64 cache from primary pipeline of jruby
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-jruby-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-jruby-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-jruby
+
+      - name: Use X64 cache from primary pipeline of x64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x64-mingw-ucrt
+      - name: Use ARM64 cache from primary pipeline of x64-mingw-ucrt
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x64-mingw-ucrt-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x64-mingw-ucrt-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x64-mingw-ucrt
+
+      - name: Use X64 cache from primary pipeline of x64-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x64-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x64-mingw32-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x64-mingw32
+      - name: Use ARM64 cache from primary pipeline of x64-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x64-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x64-mingw32-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x64-mingw32
+
+      - name: Use X64 cache from primary pipeline of x86-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86-linux-gnu-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of x86-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86-linux-gnu-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of x86-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86-linux-musl
+      - name: Use ARM64 cache from primary pipeline of x86-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86-linux-musl
+
+      - name: Use X64 cache from primary pipeline of x86-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86-mingw32-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86-mingw32
+      - name: Use ARM64 cache from primary pipeline of x86-mingw32
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86-mingw32-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86-mingw32-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86-mingw32
+
+      - name: Use X64 cache from primary pipeline of x86_64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86_64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86_64-darwin-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86_64-darwin
+      - name: Use ARM64 cache from primary pipeline of x86_64-darwin
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86_64-darwin-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86_64-darwin-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86_64-darwin
+
+      - name: Use X64 cache from primary pipeline of x86_64-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86_64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86_64-linux-gnu-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86_64-linux-gnu
+      - name: Use ARM64 cache from primary pipeline of x86_64-linux-gnu
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86_64-linux-gnu-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86_64-linux-gnu-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86_64-linux-gnu
+
+      - name: Use X64 cache from primary pipeline of x86_64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-X64
+          key: ${{ runner.os }}-on-X64-x86_64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-X64-x86_64-linux-musl-buildx
+          enableCrossOsArchive: true
+      - run: mv tmp/build-cache-X64 tmp/build-cache-X64-x86_64-linux-musl
+      - name: Use ARM64 cache from primary pipeline of x86_64-linux-musl
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/build-cache-ARM64
+          key: ${{ runner.os }}-on-ARM64-x86_64-linux-musl-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-on-ARM64-x86_64-linux-musl-buildx
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - run: mv tmp/build-cache-ARM64 tmp/build-cache-ARM64-x86_64-linux-musl
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
@@ -117,7 +381,8 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
       - name: Use cache and push docker image
         env:
-          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache-X64 --cache-from=type=local,src=tmp/build-cache-ARM64 --cache-to=type=local,dest=tmp/build-cache-new
+          RCD_IMAGE_VERSION: snapshot
+          RCD_DOCKER_BUILD: docker buildx build --cache-from=type=local,src=tmp/build-cache-X64-aarch64-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-aarch64-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-aarch64-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-aarch64-linux-musl --cache-from=type=local,src=tmp/build-cache-X64-aarch64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-ARM64-aarch64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-X64-arm-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-arm-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-arm-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-arm-linux-musl --cache-from=type=local,src=tmp/build-cache-X64-arm64-darwin --cache-from=type=local,src=tmp/build-cache-ARM64-arm64-darwin --cache-from=type=local,src=tmp/build-cache-X64-jruby --cache-from=type=local,src=tmp/build-cache-ARM64-jruby --cache-from=type=local,src=tmp/build-cache-X64-x64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-ARM64-x64-mingw-ucrt --cache-from=type=local,src=tmp/build-cache-X64-x64-mingw32 --cache-from=type=local,src=tmp/build-cache-ARM64-x64-mingw32 --cache-from=type=local,src=tmp/build-cache-X64-x86-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-x86-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-x86-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-x86-linux-musl --cache-from=type=local,src=tmp/build-cache-X64-x86-mingw32 --cache-from=type=local,src=tmp/build-cache-ARM64-x86-mingw32 --cache-from=type=local,src=tmp/build-cache-X64-x86_64-darwin --cache-from=type=local,src=tmp/build-cache-ARM64-x86_64-darwin --cache-from=type=local,src=tmp/build-cache-X64-x86_64-linux-gnu --cache-from=type=local,src=tmp/build-cache-ARM64-x86_64-linux-gnu --cache-from=type=local,src=tmp/build-cache-X64-x86_64-linux-musl --cache-from=type=local,src=tmp/build-cache-ARM64-x86_64-linux-musl  --cache-to=type=local,dest=tmp/build-cache-new
         run: |
           docker buildx create --driver docker-container --use
-          bundle exec rake release:${{matrix.platform}}
+          bundle exec rake release:images

--- a/Rakefile
+++ b/Rakefile
@@ -172,3 +172,16 @@ task :update_lists do
     EOT
   end
 end
+
+desc "Update CI publish workflows from erb"
+namespace :ci do
+  task :update_workflows do
+    erb = ERB.new(File.read(".github/workflows/publish-images.yml.erb"))
+    sdf = ".github/workflows/publish-images.yml"
+    release = false
+    File.write(sdf, erb.result(binding))
+    sdf = ".github/workflows/release-images.yml"
+    release = true
+    File.write(sdf, erb.result(binding))
+  end
+end


### PR DESCRIPTION
If images are built independent, they don't share common layers. Running the push with all caches combined fixes this.