### PR TITLE
Update to ruby-4.0.0 v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ["4.0.0-preview3", "3.4", "3.3", "3.2", "3.1", "3.0"]
+        ruby: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -192,7 +192,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [x86_64-linux, x86_64-linux-gnu]
-        ruby: ["4.0.0-preview3", "3.4", "3.3", "3.2", "3.1", "3.0"]
+        ruby: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0"]
         include:
           # declare rubygems for each ruby version
           - { ruby: "3.0", rubygems: "3.5.23" }
@@ -234,7 +234,7 @@ jobs:
           - x86_64-linux
           - x86_64-linux-gnu
           - x86_64-linux-musl
-        ruby: ["4.0.0-preview3", "3.4", "3.3", "3.2", "3.1", "3.0"]
+        ruby: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0"]
         include:
           # declare rubygems for each ruby version
           - { ruby: "3.0", rubygems: "3.5.23" }
@@ -281,7 +281,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-15]
-        ruby: ["4.0.0-preview3", "3.4", "3.3", "3.2", "3.1", "3.0"]
+        ruby: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0"]
         include:
           - os: macos-15-intel
             platform: x86_64-darwin
@@ -306,7 +306,7 @@ jobs:
             ruby: "3.4"
             platform: x64-mingw-ucrt
           - os: windows-latest
-            ruby: "head" # setup-ruby does not have 4.0 previews yet on windows
+            ruby: "4.0"
             platform: x64-mingw-ucrt
     runs-on: ${{ matrix.os }}
     steps:
@@ -352,7 +352,7 @@ jobs:
             ruby: "3.4"
             platform: x64-mingw-ucrt
           - os: windows-latest
-            ruby: "head" # setup-ruby does not have 4.0 previews yet on windows
+            ruby: "4.0"
             platform: x64-mingw-ucrt
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # `rake-compiler/rake-compiler-dock` Changelog
 
-## next / unreleased
+## 1.11.0 / 2025-12-25
 
-- Bump Ruby 4 cross-compilation support to 4.0.0-preview3. Note that ruby@094418a6 bumped the ABI in between preview2 and preview3. #179
+- Bump Ruby 4 cross-compilation support to 4.0.0.
 - Drop support for Ruby 2.7. #180
 - Remove native Ruby 3.4.8 from the host environment. #178
 

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -39,7 +39,7 @@ ENV BASH_ENV=/etc/rubybashrc
 ##
 USER rubyuser
 
-ENV RBENV_RUBIES="3.1.7 4.0.0-preview3"
+ENV RBENV_RUBIES="3.1.7 4.0.0"
 
 # Install the bootstrap rubies
 RUN bash -c " \
@@ -152,11 +152,11 @@ xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1+ is platform x64-mingw-ucrt
     ["3.3.10:3.2.9:3.1.7", "3.1.7"],
-    ["4.0.0-preview3:3.4.8", "4.0.0-preview3"],
+    ["4.0.0:3.4.8", "4.0.0"],
   ]
 elsif platform =~ /aarch64-mingw-ucrt/
   [
-    ["4.0.0-preview3:3.4.8", "4.0.0-preview3"],
+    ["4.0.0:3.4.8", "4.0.0"],
   ]
 elsif platform =~ /x64-mingw32/
   [
@@ -167,12 +167,12 @@ elsif platform =~ /x86-mingw32/
   [
     # There's no Rubyinstaller-4.x for platform x86-mingw32
     ["3.3.10:3.2.9:3.1.7:3.0.7", "3.1.7"],
-    ["3.4.8", "4.0.0-preview3"],
+    ["3.4.8", "4.0.0"],
   ]
 else
   [
     ["3.3.10:3.2.9:3.1.7:3.0.7", "3.1.7"],
-    ["4.0.0-preview3:3.4.8", "4.0.0-preview3"],
+    ["4.0.0:3.4.8", "4.0.0"],
   ]
 end
 
@@ -274,7 +274,7 @@ RUN echo 'source /etc/profile.d/rcd-env.sh' >> /etc/rubybashrc
 # Install sudoers configuration
 COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
-RUN bash -c "rbenv global 4.0.0-preview3"
+RUN bash -c "rbenv global 4.0.0"
 
 ENV RUBY_CC_VERSION=4.0.0:3.4.8:3.3.10:3.2.9:3.1.7:3.0.7
 


### PR DESCRIPTION
The docker images and setup-ruby of ruby-4.0.0 are not yet available, but CI should go green as soon as they are.