### PR TITLE
Fix `gem inst rdoc`

### DIFF
--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -278,4 +278,7 @@ RUN bash -c "rbenv global 4.0.0"
 
 ENV RUBY_CC_VERSION=4.0.0:3.4.8:3.3.10:3.2.9:3.1.7:3.0.7
 
+# TODO: Move to native ruby install above, at the next minor release
+RUN sudo chmod go+w /usr/local/rbenv/versions/*/lib/ruby/gems/*/plugins -R
+
 CMD bash

--- a/test/test_rdoc.rb
+++ b/test/test_rdoc.rb
@@ -1,0 +1,12 @@
+require 'rake_compiler_dock'
+require 'test/unit'
+
+class TestGemRdoc < Test::Unit::TestCase
+  TEST_PLATFORM = ENV["TEST_PLATFORM"] || 'x86_64-linux'
+
+  def test_gem_inst_rdoc
+    # This verifies that gem install doesn't fail due to insufficient permissions to that rubygems plugin file:
+    #   /usr/local/rbenv/versions/4.0.0/lib/ruby/gems/4.0.0/plugins/rdoc_plugin.rb
+    RakeCompilerDock::Starter.sh "gem inst --silent rdoc", platform: TEST_PLATFORM, verbose: false
+  end
+end


### PR DESCRIPTION
It otherwise fails at installation of the rdoc plugin to rubygems, due to insufficient permissions.

Fixes #187