### PR TITLE
Bump Ruby versions to 4.0.2, 3.4.9, 3.3.11, and 3.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## next / unreleased
 
-- Fix `gem install rdoc` which failed due to insufficient permissions. #187 @larskanis
-- Bump Ruby 4.0 to v4.0.1 (from v4.0.0). @marcoroth
-- Bump Ruby 3.2 to v3.2.10 (from v3.2.9). @marcoroth
+- Fix `gem install rdoc` which failed due to insufficient permissions. #187 #192 @larskanis @flavorjones
+- Bump Ruby 4.0 to v4.0.2 (from v4.0.0). @marcoroth @flavorjones
+- Bump Ruby 3.4 to v3.4.9 (from v3.4.8). @flavorjones
+- Bump Ruby 3.3 to v3.3.11 (from v3.3.10). @flavorjones
+- Bump Ruby 3.2 to v3.2.11 (from v3.2.9). @marcoroth @flavorjones
 
 
 ## 1.11.1 / 2025-12-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next / unreleased
 
 - Fix `gem install rdoc` which failed due to insufficient permissions. #187 #192 @larskanis @flavorjones
+- Fix musl cross-compiler build by removing dead mirror URL for linux-headers. @flavorjones
 - Bump Ruby 4.0 to v4.0.2 (from v4.0.0). @marcoroth @flavorjones
 - Bump Ruby 3.4 to v3.4.9 (from v3.4.8). @flavorjones
 - Bump Ruby 3.3 to v3.3.11 (from v3.3.10). @flavorjones

--- a/Dockerfile.mri.erb
+++ b/Dockerfile.mri.erb
@@ -39,7 +39,7 @@ ENV BASH_ENV=/etc/rubybashrc
 ##
 USER rubyuser
 
-ENV RBENV_RUBIES="3.1.7 4.0.1"
+ENV RBENV_RUBIES="3.1.7 4.0.2"
 
 # Install the bootstrap rubies
 RUN bash -c " \
@@ -152,12 +152,12 @@ USER rubyuser
 xrubies_build_plan = if platform =~ /x64-mingw-ucrt/
   [
     # Rubyinstaller-3.1+ is platform x64-mingw-ucrt
-    ["3.3.10:3.2.10:3.1.7", "3.1.7"],
-    ["4.0.1:3.4.8", "4.0.1"],
+    ["3.3.11:3.2.11:3.1.7", "3.1.7"],
+    ["4.0.2:3.4.9", "4.0.2"],
   ]
 elsif platform =~ /aarch64-mingw-ucrt/
   [
-    ["4.0.1:3.4.8", "4.0.1"],
+    ["4.0.2:3.4.9", "4.0.2"],
   ]
 elsif platform =~ /x64-mingw32/
   [
@@ -167,13 +167,13 @@ elsif platform =~ /x64-mingw32/
 elsif platform =~ /x86-mingw32/
   [
     # There's no Rubyinstaller-4.x for platform x86-mingw32
-    ["3.3.10:3.2.10:3.1.7:3.0.7", "3.1.7"],
-    ["3.4.8", "4.0.1"],
+    ["3.3.11:3.2.11:3.1.7:3.0.7", "3.1.7"],
+    ["3.4.9", "4.0.2"],
   ]
 else
   [
-    ["3.3.10:3.2.10:3.1.7:3.0.7", "3.1.7"],
-    ["4.0.1:3.4.8", "4.0.1"],
+    ["3.3.11:3.2.11:3.1.7:3.0.7", "3.1.7"],
+    ["4.0.2:3.4.9", "4.0.2"],
   ]
 end
 
@@ -275,8 +275,8 @@ RUN echo 'source /etc/profile.d/rcd-env.sh' >> /etc/rubybashrc
 # Install sudoers configuration
 COPY build/sudoers /etc/sudoers.d/rake-compiler-dock
 
-RUN bash -c "rbenv global 4.0.1"
+RUN bash -c "rbenv global 4.0.2"
 
-ENV RUBY_CC_VERSION=4.0.1:3.4.8:3.3.10:3.2.10:3.1.7:3.0.7
+ENV RUBY_CC_VERSION=4.0.2:3.4.9:3.3.11:3.2.11:3.1.7:3.0.7
 
 CMD bash

--- a/build/mk_musl_cross.sh
+++ b/build/mk_musl_cross.sh
@@ -29,7 +29,7 @@ GCC_CONFIG += --disable-libquadmath --disable-decimal-float
 GCC_CONFIG += --disable-multilib
 EOF
 
-make -j$(nproc) install LINUX_HEADERS_SITE=http://mirrors.2f30.org/sabotage/tarballs/
+make -j$(nproc) install
 
 popd
 

--- a/lib/rake_compiler_dock.rb
+++ b/lib/rake_compiler_dock.rb
@@ -82,20 +82,19 @@ module RakeCompilerDock
   #
   #   RakeCompilerDock.cross_rubies
   #   # => {
-  #   #      "3.4" => "3.4.8",
-  #   #      "3.3" => "3.3.10",
-  #   #      "3.2" => "3.2.10",
+  #   #      "3.4" => "3.4.9",
+  #   #      "3.3" => "3.3.11",
+  #   #      "3.2" => "3.2.11",
   #   #      "3.1" => "3.1.7",
   #   #      "3.0" => "3.0.7",
-  #   #      "2.7" => "2.7.8",
   #   #    }
   #
   def cross_rubies
     {
-      "4.0" => "4.0.1",
-      "3.4" => "3.4.8",
-      "3.3" => "3.3.10",
-      "3.2" => "3.2.10",
+      "4.0" => "4.0.2",
+      "3.4" => "3.4.9",
+      "3.3" => "3.3.11",
+      "3.2" => "3.2.11",
       "3.1" => "3.1.7",
       "3.0" => "3.0.7",
     }
@@ -111,14 +110,14 @@ module RakeCompilerDock
   # Note that the returned string will contain versions sorted in descending order.
   #
   # For example:
-  #   RakeCompilerDock.ruby_cc_version("2.7", "3.4")
-  #   # => "3.4.8:2.7.8"
+  #   RakeCompilerDock.ruby_cc_version("3.0", "3.4")
+  #   # => "3.4.9:3.0.7"
   #
   #   RakeCompilerDock.ruby_cc_version("~> 3.2")
-  #   # => "3.4.8:3.3.10:3.2.10"
+  #   # => "3.4.9:3.3.11:3.2.11"
   #
   #   RakeCompilerDock.ruby_cc_version(Gem::Requirement.new("~> 3.2"))
-  #   # => "3.4.8:3.3.10:3.2.10"
+  #   # => "3.4.9:3.3.11:3.2.11"
   #
   def ruby_cc_version(*requirements)
     cross = cross_rubies


### PR DESCRIPTION
## Summary

- Bump Ruby 4.0 to v4.0.2 (from v4.0.1)
- Bump Ruby 3.4 to v3.4.9 (from v3.4.8)
- Bump Ruby 3.3 to v3.3.11 (from v3.3.10)
- Bump Ruby 3.2 to v3.2.11 (from v3.2.10)
- Fix musl cross-compiler build: remove dead `LINUX_HEADERS_SITE` mirror override (`http://mirrors.2f30.org/sabotage/tarballs/`), using upstream default instead