### PR TITLE
Generate merge manifest also for jruby image

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,6 +144,9 @@ namespace :release do
         sh "docker buildx imagetools create -t #{tag.sub("linux-gnu", "linux")} #{tag}-ARM64 #{tag}-X64"
       end
     end
+
+    jruby_tag = RakeCompilerDock::Starter.container_image_name(rubyvm: "jruby")
+    sh "docker buildx imagetools create -t #{jruby_tag} #{jruby_tag}-ARM64 #{jruby_tag}-X64"
   end
 
   desc "Show download sizes of the release images"


### PR DESCRIPTION
Extend `release:manifests` to merge the jruby per-arch images into `<version>-jruby`, matching what's already done for MRI platforms. Both workflows already depend on the `jruby` job and invoke this rake task, so no workflow changes are needed.

I've gone back and manually created the missing manifests for previous releases 1.11.2 and 1.12.0.