### PR TITLE
dep: relax some dev requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,10 +239,10 @@ jobs:
           # declare rubygems for each ruby version
           - { ruby: "3.0", rubygems: "3.5.23" }
           # declare docker image for each platform
-          - { platform: aarch64-linux-musl, runon: "ubuntu-24.04-arm", docker_tag: "-alpine" }
-          - { platform: arm-linux-musl, runon: "ubuntu-24.04-arm", docker_tag: "-alpine" }
-          - { platform: x86-linux-musl, runon: "ubuntu-latest", docker_tag: "-alpine" }
-          - { platform: x86_64-linux-musl, runon: "ubuntu-latest", docker_tag: "-alpine" }
+          - { platform: aarch64-linux-musl, runon: "ubuntu-24.04-arm", docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
+          - { platform: arm-linux-musl, runon: "ubuntu-24.04-arm", docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
+          - { platform: x86-linux-musl, runon: "ubuntu-latest", docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
+          - { platform: x86_64-linux-musl, runon: "ubuntu-latest", docker_tag: "-alpine", bootstrap: "apk add build-base &&" }
           - { platform: x86_64-linux, runon: "ubuntu-latest" }
           - { platform: x86_64-linux-gnu, runon: "ubuntu-latest" }
           # declare docker platform for each platform
@@ -267,6 +267,7 @@ jobs:
           docker run --rm -v $PWD:/work -w /work \
             ${{ matrix.docker_platform}} ruby:${{ matrix.ruby }}${{ matrix.docker_tag }} \
             sh -c "
+              ${{ matrix.bootstrap }}
               if test -n '${{ matrix.rubygems }}' ; then gem update --system ${{ matrix.rubygems }} ; fi &&
               gem install --local *.gem --verbose &&
               cd test/rcd_test/ &&

--- a/rake-compiler-dock.gemspec
+++ b/rake-compiler-dock.gemspec
@@ -28,7 +28,7 @@ Use rake-compiler-dock to enter an interactive shell session or add a task to yo
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", ">= 1.7", "< 3.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 12"
   spec.add_development_dependency "test-unit", "~> 3.0"
 end

--- a/test/env/Dockerfile.alpine
+++ b/test/env/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG from_image
 FROM ${from_image}
 
 RUN uname -a
-RUN apk add ruby ruby-rake git
+RUN apk add ruby ruby-dev ruby-rake git build-base
 
 RUN ruby --version
 RUN gem env

--- a/test/env/Dockerfile.debian
+++ b/test/env/Dockerfile.debian
@@ -8,7 +8,7 @@ RUN uname -a
 RUN apt-get update -qq && \
   apt-get install -yq \
   -o Dpkg::Options::='--force-confnew' \
-  ruby \
+  ruby ruby-dev build-essential \
   git
 
 RUN ruby --version

--- a/test/rcd_test/Gemfile
+++ b/test/rcd_test/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # No rcd_test gem, since "bundle package" fails on bundler-2.7+, if the extension isn't built
 # gemspec
 
-gem "rake", "~> 13.0"
+gem "rake"
 gem "rake-compiler"
 gem "rake-compiler-dock", path: "../.."
-gem "minitest", "~> 5.0"
+gem "minitest"


### PR DESCRIPTION
- so we can use Bundler 4
- so minitest 6 and prism can be used without errors

See failing job at https://github.com/rake-compiler/rake-compiler-dock/actions/runs/24780671262/job/72512939203?pr=198

Note that I've also tweaked some of the CI containers so that Prism will build from source (it's a dependency of Minitest 6). This is not great, and will slow things down, but I'm working on precompiling Prism in https://github.com/ruby/prism/pull/4080 and we can probably revert these commits once that's shipped.
